### PR TITLE
Cleaner output from testing command

### DIFF
--- a/config/karma-base.conf.js
+++ b/config/karma-base.conf.js
@@ -2,7 +2,7 @@ module.exports = {
   basePath: '..',
   singleRun: true,
   client: {
-    captureConsole: false
+    captureConsole: true
   },
   browsers: [
     'PhantomJS'

--- a/config/karma-testing.conf.js
+++ b/config/karma-testing.conf.js
@@ -7,6 +7,10 @@ karmaConfig.reporters = [
   'tap'
 ];
 
+karmaConfig.tapReporter = {
+  disableStdout: true
+};
+
 module.exports = function (config) {
   config.set(karmaConfig);
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack --config config/webpack.config.js",
     "build:reference": "cd app/resonant-reference-app && webpack",
-    "test": "karma start config/karma-testing.conf.js | faucet",
+    "test": "karma start config/karma-testing.conf.js | grep '^PhantomJS' | sed \"s/^.*LOG: '\\(.*\\)'$/\\1/\" | faucet",
     "cover": "karma start config/karma-coverage.conf.js",
     "cover:report": "http-server coverage -p ${PORT-3000}"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "webpack --config config/webpack.config.js",
     "build:reference": "cd app/resonant-reference-app && webpack",
     "test": "karma start config/karma-testing.conf.js | grep '^PhantomJS' | sed \"s/^.*LOG: '\\(.*\\)'$/\\1/\" | faucet",
+    "test:raw": "karma start config/karma-testing.conf.js",
     "cover": "karma start config/karma-coverage.conf.js",
     "cover:report": "http-server coverage -p ${PORT-3000}"
   },


### PR DESCRIPTION
This adds a command line filter to the NPM test script (along with some testing configuration changes) to capture and reformat the output in such a way that ``faucet`` is better able to process and pretty print the results.