### PR TITLE
Resize mixin

### DIFF
--- a/app/resize/index.js
+++ b/app/resize/index.js
@@ -1,6 +1,6 @@
 import candela from './../../src/candela';
+import AutoResize from './../../src/candela/VisComponent/mixin/AutoResize';
 import indexContent from './index.jade';
-import 'javascript-detect-element-resize/detect-element-resize';
 import './index.styl';
 
 function showPage () {
@@ -25,16 +25,20 @@ window.addEventListener('load', () => {
   }
 
   [...document.getElementsByClassName('vis-element')].forEach(el => {
-    let vis = new candela.components.Scatter(
+    let vis = new (AutoResize(candela.components.Scatter))(
       el,
-      data,
       {
+        data,
         x: 'x',
         y: 'y'
       }
     );
     vis.render();
-    window.addResizeListener(el, () => vis.render());
+
+    vis.on('resize', (w, h, me) => {
+      console.log(`resize event: ${w}, ${h}`);
+      me.render();
+    });
   });
 
   window.setInterval(() => {

--- a/app/resize/index.js
+++ b/app/resize/index.js
@@ -1,5 +1,5 @@
 import candela from './../../src/candela';
-import AutoResize from './../../src/candela/VisComponent/mixin/AutoResize';
+import Resize from './../../src/candela/VisComponent/mixin/Resize';
 import indexContent from './index.jade';
 import './index.styl';
 
@@ -25,7 +25,7 @@ window.addEventListener('load', () => {
   }
 
   [...document.getElementsByClassName('vis-element')].forEach(el => {
-    let vis = new (AutoResize(candela.components.Scatter))(
+    let vis = new (Resize(candela.components.Scatter))(
       el,
       {
         data,

--- a/src/candela/VisComponent/index.js
+++ b/src/candela/VisComponent/index.js
@@ -1,5 +1,3 @@
-import telegraph from 'telegraph-events';
-
 export default class VisComponent {
   constructor (el) {
     if (!el) {
@@ -7,8 +5,6 @@ export default class VisComponent {
     }
 
     this.el = el;
-
-    telegraph(this);
   }
 
   render () {

--- a/src/candela/VisComponent/mixin/AutoResize.js
+++ b/src/candela/VisComponent/mixin/AutoResize.js
@@ -1,0 +1,18 @@
+import 'javascript-detect-element-resize/detect-element-resize';
+import Events from './Events';
+
+let AutoResize = Base => class extends Events(Base) {
+  constructor (...args) {
+    super(...args);
+
+    window.addResizeListener(this.el, () => {
+      const style = window.getComputedStyle(this.el);
+      const width = window.parseInt(style.getPropertyValue('width'));
+      const height = window.parseInt(style.getPropertyValue('height'));
+
+      this.emit('resize', width, height, this);
+    });
+  }
+};
+
+export default AutoResize;

--- a/src/candela/VisComponent/mixin/Events.js
+++ b/src/candela/VisComponent/mixin/Events.js
@@ -1,0 +1,10 @@
+import telegraph from 'telegraph-events';
+
+let Events = Base => class extends Base {
+  constructor (...args) {
+    super(...args);
+    telegraph(this);
+  }
+};
+
+export default Events;

--- a/src/candela/VisComponent/mixin/Resize.js
+++ b/src/candela/VisComponent/mixin/Resize.js
@@ -1,7 +1,7 @@
 import 'javascript-detect-element-resize/detect-element-resize';
 import Events from './Events';
 
-let AutoResize = Base => class extends Events(Base) {
+let Resize = Base => class extends Events(Base) {
   constructor (...args) {
     super(...args);
 
@@ -15,4 +15,4 @@ let AutoResize = Base => class extends Events(Base) {
   }
 };
 
-export default AutoResize;
+export default Resize;

--- a/src/candela/VisComponent/test/events.js
+++ b/src/candela/VisComponent/test/events.js
@@ -1,0 +1,46 @@
+import test from 'tape';
+
+import VisComponent from '..';
+import Events from '../mixin/Events';
+
+test('Events mixin for VisComponent', t => {
+  t.plan(5);
+
+  let EventedVisComponent = class extends Events(VisComponent) {
+    constructor (el, options) {
+      super(el);
+
+      this.options = options;
+    }
+
+    render () {
+      this.value = this.options.value;
+    }
+
+    emitEvent () {
+      this.emit('foobar', this.value);
+    }
+  };
+
+  const el = 'I am a fake element';
+  const options = {
+    value: 42
+  };
+
+  let v = new EventedVisComponent(el, options);
+
+  // Make sure the mixin mixed in.
+  t.ok(v.emit, 'Component has emit() method from mixin');
+  t.ok(v.on, 'Component has on() method from mixin');
+
+  // Make sure the mixin didn't disrupt the constructor.
+  t.equal(el, v.el, 'VisComponent constructor executed');
+
+  // Make sure the mixin didn't disrupt the render() method.
+  v.render();
+  t.equal(v.value, options.value);
+
+  // Make sure we can catch triggered events from the component.
+  v.on('foobar', value => t.equal(value, options.value, 'Event is emitted properly'));
+  v.emitEvent();
+});

--- a/src/candela/components/LineChart/index.js
+++ b/src/candela/components/LineChart/index.js
@@ -1,8 +1,9 @@
 import VisComponent from '../../VisComponent';
+import Events from '../../VisComponent/mixin/Events';
 import vcharts from '../../../vcharts';
 import spec from './spec.json';
 
-export default class LineChart extends VisComponent {
+export default class LineChart extends Events(VisComponent) {
   constructor (el, data) {
     super(el);
 

--- a/src/candela/components/Scatter/index.js
+++ b/src/candela/components/Scatter/index.js
@@ -1,7 +1,8 @@
+import VisComponent from '../../VisComponent';
 import vcharts from '../../../vcharts';
 import spec from './spec.json';
 
-export default class Scatter {
+export default class Scatter extends VisComponent {
   static get spec () {
     return {
       options: [
@@ -75,6 +76,7 @@ export default class Scatter {
   }
 
   constructor (el, options) {
+    super(el);
     this.chart = vcharts.chart(spec, el, options);
   }
 


### PR DESCRIPTION
Adds a mixin to handle resizing of containing element. The mixin emits a resize event whenever the containing element's size changes, allowing each component to react properly to the notice. For example, the example resize application simply prints a message on the console and then calls ``render()`` to refresh the component.

Depends on #78