### PR TITLE
Moving to strict padding

### DIFF
--- a/src/candela/components/Bar/spec.json
+++ b/src/candela/components/Bar/spec.json
@@ -10,7 +10,7 @@
   {
     "width": ["@get", "width", 800],
     "height": ["@get", "height", 500],
-    "padding": ["@get", "padding", {"top": 20, "bottom": 200, "left": 100, "right": ["@if", ["@get", "color"], 150, 10]}],
+    "padding": "strict",
     "predicates": [
       {
         "name": "tooltip",

--- a/src/candela/components/Box/spec.json
+++ b/src/candela/components/Box/spec.json
@@ -53,7 +53,7 @@
     {
       "name": "boxplot",
       "height": ["@get", "height", 400],
-      "padding": ["@get", "padding", {"left": 100, "right": 10, "top": 10, "bottom": ["@if", ["@get", "horiz"], 50, 150]}],
+      "padding": "strict",
       "width": ["@get", "width", 600],
       "data": [
         {

--- a/src/candela/components/Bullet/spec.json
+++ b/src/candela/components/Bullet/spec.json
@@ -17,17 +17,7 @@
   {
     "width": ["@get", "width"],
     "height": ["@get", "height"],
-    "padding": {
-      "top": 10,
-      "left": [
-        "@if",
-        ["@get", "title", ""],
-        150,
-        10
-      ],
-      "bottom": 30,
-      "right": 10
-    },
+    "padding": "strict",
     "data": [
       {
         "name": "ranges",
@@ -66,7 +56,7 @@
       {
         "name": "y",
         "type": "linear",
-        "range": [0, ["@get", "height"]],
+        "range": "height",
         "domain": [0, 1]
       },
       {

--- a/src/candela/components/Gantt/spec.json
+++ b/src/candela/components/Gantt/spec.json
@@ -34,7 +34,7 @@
     {
       "width": ["@get", "width"],
       "height": ["@get", "height"],
-      "padding": ["@get", "padding", {"top": 10, "bottom": 50, "left": 200, "right": 10}],
+      "padding": "strict",
       "data": [
         {
           "name": "data",

--- a/src/candela/components/Histogram/spec.json
+++ b/src/candela/components/Histogram/spec.json
@@ -95,7 +95,7 @@
       {
         "width": ["@get", "width"],
         "height": ["@get", "height"],
-        "padding": ["@get", "padding", {"top": 20, "bottom": ["@if", ["@get", "discrete"], 150, 50], "left": 50, "right": 10}],
+        "padding": "strict",
         "predicates": [
           {
             "name": "tooltip",

--- a/src/candela/components/Line/spec.json
+++ b/src/candela/components/Line/spec.json
@@ -70,7 +70,7 @@
       {
         "width": ["@get", "width"],
         "height": ["@get", "height"],
-        "padding": ["@get", "padding", {"top": 10, "bottom": 50, "left": 50, "right": ["@if", ["@get", "legend"], 150, 10]}],
+        "padding": "strict",
         "predicates": [
           {
             "name": "tooltip",

--- a/src/candela/components/LineChart/spec.json
+++ b/src/candela/components/LineChart/spec.json
@@ -58,7 +58,7 @@
     {
       "width": ["@get", "width"],
       "height": ["@get", "height"],
-      "padding": ["@get", "padding", {"top": 10, "bottom": 50, "left": 50, "right": ["@if", ["@get", "legend"], 150, 10]}],
+      "padding": "strict",
       "predicates": [
         {
           "name": "tooltip",

--- a/src/candela/components/Scatter/spec.json
+++ b/src/candela/components/Scatter/spec.json
@@ -70,7 +70,7 @@
       {
         "width": ["@get", "width"],
         "height": ["@get", "height"],
-        "padding": ["@get", "padding", {"top": 10, "bottom": 50, "left": 50, "right": ["@if", ["@get", "legend"], 150, 10]}],
+        "padding": "strict",
         "predicates": [
           {
             "name": "tooltip",

--- a/src/candela/components/ScatterMatrix/spec.json
+++ b/src/candela/components/ScatterMatrix/spec.json
@@ -1,16 +1,7 @@
 {
   "width": ["@get", "width", 600],
   "height": ["@get", "height", 600],
-  "padding": [
-    "@get",
-    "padding",
-    {
-      "top": 30,
-      "bottom": 10,
-      "left": 100,
-      "right": ["@if", ["@get", "color"], 150, 10]
-    }
-  ],
+  "padding": "strict",
   "data": [
     {
       "name": "data",

--- a/src/candela/util/vega/axis.json
+++ b/src/candela/util/vega/axis.json
@@ -5,7 +5,10 @@
       "event",
       ["@if", ["@eq", ["@get", "axis"], "x"], "eventX()", "eventY()"]
     ],
-    ["sizeSignal", ["@join", "", [["@get", "axis"], "size"]]],
+    [
+      "sizeSignal",
+      ["@if", ["@eq", ["@get", "axis"], "x"], "width", "height"]
+    ],
     ["pointSignal", ["@join", "", [["@get", "axis"], "point"]]],
     ["deltaSignal", ["@join", "", [["@get", "axis"], "delta"]]],
     ["anchorSignal", ["@join", "", [["@get", "axis"], "anchor"]]],
@@ -17,10 +20,6 @@
   ],
   {
     "signals": [
-      {
-        "name": ["@get", "sizeSignal"],
-        "init": ["@get", "size"]
-      },
       {
         "name": ["@get", "pointSignal"],
         "init": 0,
@@ -171,10 +170,7 @@
       {
         "name": ["@get", "axis"],
         "type": ["@get", "type", "linear"],
-        "range": ["@if", ["@eq", ["@get", "axis"], "x"],
-          [0, ["@get", "size"]],
-          [["@get", "size"], 0]
-        ],
+        "range": ["@get", "sizeSignal"],
         "points": ["@get", "points", false],
         "zero": ["@get", "zero", false],
         "nice": ["@get", "nice", false],

--- a/src/candela/util/vega/index.js
+++ b/src/candela/util/vega/index.js
@@ -395,11 +395,8 @@ let chart = function (template, el, initialOptions, done) {
   that.update = function (newOptions) {
     that.options = extend(that.options, newOptions);
 
-    // Transform pass 1 to get the padding
-    let spec = transform(that.template, that.options);
-
-    // Use padding and element size to set size, unless
-    // size explicitly specified or element size is zero.
+    // Use element size to set size, unless size explicitly specified or
+    // element size is zero.
     let el = d3.select(that.el)[0][0];
     let sizeOptions = {};
 
@@ -410,15 +407,9 @@ let chart = function (template, el, initialOptions, done) {
     if (elWidth !== 0 && elHeight !== 0) {
       if (that.options.width === undefined) {
         sizeOptions.width = elWidth;
-        if (isObjectLiteral(spec.padding)) {
-          sizeOptions.width -= spec.padding.left + spec.padding.right;
-        }
       }
       if (that.options.height === undefined) {
         sizeOptions.height = elHeight;
-        if (isObjectLiteral(spec.padding)) {
-          sizeOptions.height -= spec.padding.top + spec.padding.bottom;
-        }
       }
     }
     let curOptions = extend(that.options, sizeOptions);
@@ -429,7 +420,6 @@ let chart = function (template, el, initialOptions, done) {
       renderer: curOptions.renderer
     };
 
-    // Transform pass 2 to get the final visualization
     that.spec = transform(that.template, curOptions);
 
     vg.parse.spec(that.spec, function (chartObj) {


### PR DESCRIPTION
Fixes #85. This solves several things:

 - Simplifies all Vega specs to eliminate special padding logic

 - Prompted the use of the new width and height signals so all pan/zoom axes are simpler now

 - Biggest one: we were rendering Vega specs twice. Once to get the padding
   to use for fixing up the width and height, then again for the final render.
   With strict mode this is no longer needed, removing some hacky code.