### PR TITLE
Don't npmignore the src dir

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
 app
 build
-webpack.config.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 app
 build
-src
 webpack.config.js


### PR DESCRIPTION
This enables chained webpack import/require of sections of the candela repo.