### PR TITLE
Make CleanWebpackPlugin work off of true project root (rather than location of config file)

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -31,9 +31,9 @@ module.exports = {
       vg: 'vega'
     }),
 
-    new CleanPlugin([
-      './build/*'
-    ]),
+    new CleanPlugin([path.resolve(__dirname, 'build/*')], {
+      root: __dirname
+    }),
 
     new HtmlPlugin({
       title: 'Candela Examples',


### PR DESCRIPTION
Fixes #153