### PR TITLE
Avoid ephemeral ports for testing

### DIFF
--- a/script/test-server-up.sh
+++ b/script/test-server-up.sh
@@ -2,5 +2,5 @@ if [ -e .server.pid ]; then
   echo "Server seems to already be running (PID $(cat .server.pid))" >&2
   exit 1
 fi
-http-server -p 38000 build &
+http-server -p 28000 build &
 echo $! > .server.pid

--- a/src/candela/components/Bar/test/bar.image.js
+++ b/src/candela/components/Bar/test/bar.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'bar',
-  url: 'http://localhost:38000/examples/#bar',
+  url: 'http://localhost:28000/examples/#bar',
   selector: '#vis-element',
   threshold: 0.001
 });

--- a/src/candela/components/Box/test/box.image.js
+++ b/src/candela/components/Box/test/box.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'box',
-  url: 'http://localhost:38000/examples/#box',
+  url: 'http://localhost:28000/examples/#box',
   selector: '#vis-element',
   threshold: 0.001
 });

--- a/src/candela/components/Bullet/test/bullet.image.js
+++ b/src/candela/components/Bullet/test/bullet.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'bullet',
-  url: 'http://localhost:38000/examples/#bullet',
+  url: 'http://localhost:28000/examples/#bullet',
   selector: '#vis-element',
   threshold: 0.001
 });

--- a/src/candela/components/Gantt/test/gantt.image.js
+++ b/src/candela/components/Gantt/test/gantt.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'gantt',
-  url: 'http://localhost:38000/examples/#gantt',
+  url: 'http://localhost:28000/examples/#gantt',
   selector: '#vis-element',
   threshold: 0.001
 });

--- a/src/candela/components/Heatmap/test/heatmap.image.js
+++ b/src/candela/components/Heatmap/test/heatmap.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'heatmap',
-  url: 'http://localhost:38000/examples/#heatmap',
+  url: 'http://localhost:28000/examples/#heatmap',
   selector: '#vis-element',
   threshold: 0.001
 });

--- a/src/candela/components/Histogram/test/histogram.image.js
+++ b/src/candela/components/Histogram/test/histogram.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'histogram',
-  url: 'http://localhost:38000/examples/#histogram',
+  url: 'http://localhost:28000/examples/#histogram',
   selector: '#vis-element',
   threshold: 0.001
 });

--- a/src/candela/components/Line/test/line.image.js
+++ b/src/candela/components/Line/test/line.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'line',
-  url: 'http://localhost:38000/examples/#line',
+  url: 'http://localhost:28000/examples/#line',
   selector: '#vis-element',
   threshold: 0.001
 });

--- a/src/candela/components/LineUp/test/lineup.image.js
+++ b/src/candela/components/LineUp/test/lineup.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'lineup',
-  url: 'http://localhost:38000/examples/#lineup',
+  url: 'http://localhost:28000/examples/#lineup',
   selector: '#vis-element',
   delay: 2000,
   threshold: 0.001

--- a/src/candela/components/Scatter/test/scatter.image.js
+++ b/src/candela/components/Scatter/test/scatter.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'scatter',
-  url: 'http://localhost:38000/examples/#scatter',
+  url: 'http://localhost:28000/examples/#scatter',
   selector: '#vis-element',
   threshold: 0.001
 });

--- a/src/candela/components/ScatterMatrix/test/scattermatrix.image.js
+++ b/src/candela/components/ScatterMatrix/test/scattermatrix.image.js
@@ -2,7 +2,7 @@ import imageTest from '../../../util/imageTest';
 
 imageTest({
   name: 'scattermatrix',
-  url: 'http://localhost:38000/examples/#scattermatrix',
+  url: 'http://localhost:28000/examples/#scattermatrix',
   selector: '#vis-element',
   threshold: 0.001
 });


### PR DESCRIPTION
28000 doesn't lie in the ephemeral port range on Linux, while 38000 does.

Thanks @manthey for bringing this to my attention.