### PR TITLE
Exclude dist and build directories from linting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 build
 coverage
+dist
 .server.pid
 .server.log
 npm-debug.log

--- a/config/karma-coverage.conf.js
+++ b/config/karma-coverage.conf.js
@@ -23,6 +23,13 @@ karmaConfig.coverageReporter = {
       type: 'lcovonly',
       dir: 'coverage',
       subdir: 'lcov'
+    },
+
+    {
+      type: 'cobertura',
+      dir: 'coverage/',
+      file: 'coverage.xml',
+      subdir: 'cobertura'
     }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "ignore": [
       "config",
       "src/external",
-      "app/resonant-laboratory/web_client/lib"
+      "app/resonant-laboratory/web_client/lib",
+      "dist",
+      "built"
     ]
   },
   "repository": {


### PR DESCRIPTION
Otherwise, you can't npm run lint in the same directory where you build candela without getting errors.

Add cobertura coverage output to work with other coverage tools (eventually we can send this to cdash).  I have a local tool which works with these files.