### PR TITLE
Fully delete unused options instead of setting to null

### DIFF
--- a/app/resonant-laboratory/views/widgets/VisualizationView/index.js
+++ b/app/resonant-laboratory/views/widgets/VisualizationView/index.js
@@ -119,9 +119,9 @@ let VisualizationView = Widget.extend({
         // The visualization hasn't changed, but the options may have.
         Object.keys(this.vis.options).forEach(key => {
           if (!options.hasOwnProperty(key)) {
-            // This option is no longer specified; set it to
-            // null so that it's removed from the visualization
-            options[key] = null;
+            // This option is no longer specified;
+            // remove it so that it's removed from the visualization
+            delete options[key];
           }
         });
 


### PR DESCRIPTION
This bug manifests when you set then unset a property (in particular I saw this in the `id` option of Heatmap). Setting an option to `null` and removing it entirely could have different effects on the visualization logic. In this case setting the id option to `null` set all ids to `undefined`, creating a single row in the heatmap. On refreshing the ResLab page, the option was removed and the vis functioned normally again.