### PR TITLE
Initial OnSet visualization

### DIFF
--- a/app/examples/index.json
+++ b/app/examples/index.json
@@ -99,5 +99,9 @@
   {
     "title": "Survival Plot",
     "link": "survival"
+  },
+  {
+    "title": "OnSet",
+    "link": "onset"
   }
 ]

--- a/app/examples/onset/index.js
+++ b/app/examples/onset/index.js
@@ -1,0 +1,17 @@
+import { simpsons } from '../util/datasets';
+import showComponent from '../util/showComponent';
+
+window.onload = () => {
+  showComponent('OnSet', 'div', {
+    data: simpsons,
+    id: 'Name',
+    sets: [
+      'Male',
+      'Power Plant',
+      'Evil',
+      'Blue Hair',
+      'Duff Fan',
+      'School'
+    ]
+  });
+};

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   "dependencies": {
     "LineUpJS": "git+https://github.com/Caleydo/lineup.js#0cd7f3f2ad06c498c09612daf5f3e2a36c07536d",
     "UpSet": "git+https://github.com/VCG/upset#6e8b7a172443dd6b4f4324d1a3368287e9e9c089",
+    "onset": "git+https://github.com/Kitware/setvis#238c57a0bc2d37feb898d7ec630f481529bd528b",
     "brace": "^0.7.0",
     "d3": "^3.5.14",
     "datalib": "^1.6.3",

--- a/src/candela/components/OnSet/README.md
+++ b/src/candela/components/OnSet/README.md
@@ -1,0 +1,64 @@
+# [candela](../..#readme).[components](..#readme).OnSet
+
+An [OnSet](http://www.cc.gatech.edu/gvu/ii/setvis/) set visualization.
+
+OnSet interprets binary columns (i.e. columns with a literal `"0"` or `"1"`,
+`"true"` or `"false"`, `"yes"` or `"no"` in every row) as sets.
+Any field in the `sets` option will be interpreted in
+this way. Since most data is not arranged in binary columns, the visualization
+also supports arbitrary categorical fields with the `fields` option.
+Each field specified in this list will first be preprocessed into a collection
+sets, one for each field value, with the name `"<fieldName> <value>"`.
+
+For example, suppose the data table is:
+
+| id | f1 | f2 |
+| :-- | :-- | :-- |
+| n1 | 1 | x |
+| n2 | 0 | x |
+| n3 | 0 | y |
+
+You could create an OnSet visualization with the following options:
+
+```js
+new OnSet({
+  data: data,
+  id: 'id',
+  sets: ['f1'],
+  fields: ['f2']
+});
+```
+
+This would preprocess the `f2` field into `f2 x` and `f2 y` sets as follows
+and make them available to OnSet:
+
+```
+f1: n1
+f2 x: n1, n2
+f2 y: n3
+```
+
+If the `rowSets` option is set to `true`, the set membership is transposed
+and the sets become:
+
+```
+n1: f1, f2 x
+n2: f2 x
+n3: f2 y
+```
+
+**extends** [VisComponent](../../VisComponent#readme)
+
+### new OnSet(el, options)
+
+* **el** is the DOM element that will contain the visualization.
+
+* **options** is an object with the following fields:
+
+| Option     | Type   | Description  |
+| :--------  | :----- | :----------- |
+| data       | [Table](../..#table) | The data table. |
+| id         | String | A field containing unique ids for each record. |
+| sets       | Array of String | A list of fields containing 0/1 set membership information which will be populated in the OnSet view. |
+| fields     | Array of String | A list of categorical fields that will be translated into collections of 0/1 sets for every distinct value in each field and populated in the OnSet view. |
+| rowSets    | Boolean | If `false`, treat the columns as sets, if `true`, treat the rows as sets. Default is `false`. |

--- a/src/candela/components/OnSet/index.js
+++ b/src/candela/components/OnSet/index.js
@@ -1,8 +1,9 @@
 import d3 from 'd3';
 import dl from 'datalib';
 import onset from 'onset';
+import VisComponent from '../../VisComponent';
 
-export default class OnSet {
+export default class OnSet extends VisComponent {
   static get options () {
     return [
       {
@@ -44,7 +45,7 @@ export default class OnSet {
   }
 
   constructor (el, options) {
-    this.el = el;
+    super(el);
     this.options = options;
   }
 

--- a/src/candela/components/OnSet/index.js
+++ b/src/candela/components/OnSet/index.js
@@ -1,0 +1,120 @@
+import d3 from 'd3';
+import dl from 'datalib';
+import onset from 'onset';
+
+export default class OnSet {
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'id',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'sets',
+        type: 'string_list',
+        format: 'string_list',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['integer', 'boolean']
+        }
+      },
+      {
+        name: 'fields',
+        type: 'string_list',
+        format: 'string_list',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      }
+    ];
+  }
+
+  constructor (el, options) {
+    this.el = el;
+    this.options = options;
+  }
+
+  render () {
+    if (!this.options.id || (!this.options.sets && !this.options.fields)) {
+      return;
+    }
+
+    d3.select(this.el).html(onset.template);
+
+    // Swizzle the data into what OnSet expects (csv of form id,set1,set2,...)
+    let data = [];
+    this.options.data.forEach(d => {
+      data.push([d[this.options.id]]);
+    });
+
+    // Add 0/1 sets.
+    if (this.options.sets) {
+      const membershipVals = ['1', 'yes', 'true'];
+      this.options.data.forEach((d, i) => {
+        this.options.sets.forEach(s => {
+          const strVal = ('' + d[s]).toLowerCase();
+          if (membershipVals.indexOf(strVal) !== -1) {
+            data[i].push(s);
+          }
+        });
+      });
+    }
+
+    // Add sets derived from general fields.
+    // A set is defined by records sharing a field value.
+    if (this.options.fields) {
+      this.options.fields.forEach(field => {
+        let distinct = dl.unique(this.options.data, d => d[field]);
+        this.options.data.forEach((d, i) => {
+          distinct.forEach(v => {
+            if (v === d[field]) {
+              data[i].push(field + ' ' + v);
+            }
+          });
+        });
+      });
+    }
+
+    let csvData = '';
+    if (this.options.rowSets) {
+      data.forEach(d => {
+        csvData += d.join(',') + '\n';
+      });
+    } else {
+      let sets = {};
+      data.forEach(d => {
+        d.forEach((s, i) => {
+          if (i === 0) {
+            return;
+          }
+          if (sets[s] === undefined) {
+            sets[s] = [s];
+          }
+          sets[s].push(d[0]);
+        });
+      });
+      Object.keys(sets).forEach(s => {
+        csvData += sets[s].join(',') + '\n';
+      });
+    }
+
+    window.sessionStorage.setItem('datatype', 'custom');
+    window.sessionStorage.setItem('data', csvData);
+
+    onset.main();
+  }
+}

--- a/src/candela/components/README.md
+++ b/src/candela/components/README.md
@@ -10,6 +10,7 @@
 * [Histogram](Histogram#readme)
 * [LineChart](LineChart#readme)
 * [LineUp](LineUp#readme)
+* [OnSet](OnSet#readme)
 * [ScatterPlot](ScatterPlot#readme)
 * [ScatterPlotMatrix](ScatterPlotMatrix#readme)
 * [UpSet](UpSet#readme)

--- a/src/candela/components/index.js
+++ b/src/candela/components/index.js
@@ -8,6 +8,7 @@ import Heatmap from './Heatmap';
 import Histogram from './Histogram';
 import LineChart from './LineChart';
 import LineUp from './LineUp';
+import OnSet from './OnSet';
 import ParallelCoordinates from './ParallelCoordinates';
 import ScatterPlot from './ScatterPlot';
 import ScatterPlotMatrix from './ScatterPlotMatrix';
@@ -25,6 +26,7 @@ export default {
   Histogram,
   LineChart,
   LineUp,
+  OnSet,
   ParallelCoordinates,
   ScatterPlot,
   ScatterPlotMatrix,

--- a/src/candela/test/exports.js
+++ b/src/candela/test/exports.js
@@ -13,6 +13,7 @@ const componentList = [
   'Histogram',
   'LineChart',
   'LineUp',
+  'OnSet',
   'ParallelCoordinates',
   'ScatterPlot',
   'ScatterPlotMatrix',


### PR DESCRIPTION
Fixes #224. This initial version incorporates the OnSet code directly (original is at https://github.com/tmajor86/setvis). There were several changes needed to make it modular. Since this is over 5K lines of code, we may want to think about how this is maintained going forward. The OnSet changes could be upstreamed or maintained in an OnSet fork. For simplicity this branch is a decent way to try out the integration before we decide what to do.