### PR TITLE
The example csvs were not being parsed as expected.

### DIFF
--- a/app/examples/index.js
+++ b/app/examples/index.js
@@ -12,9 +12,9 @@ import visualizations from './visualizations.json';
 
 let datasets = {
   iris,
-  stocks: dl.read(stocks, {type: 'csv'}),
-  msft: dl.read(msft, {type: 'csv'}),
-  simpsons: dl.read(simpsons, {type: 'csv'})
+  stocks: dl.read(stocks, {type: 'csv', parse: 'auto'}),
+  msft: dl.read(msft, {type: 'csv', parse: 'auto'}),
+  simpsons: dl.read(simpsons, {type: 'csv', parse: 'auto'})
 };
 let visMap = {};
 visualizations.forEach(v => {


### PR DESCRIPTION
Although vega datalib says that parse: 'auto' is the default, I found that this needs to be specified explicitly or it is not done.  For example, loading a csv file, all of the fields are strings and datalib.type.all(data) will return string for all columns.