### PR TITLE
Increase overlay z-index for overlays to be above 100

### DIFF
--- a/app/resonant-laboratory/views/layout/HelpLayer/style.css
+++ b/app/resonant-laboratory/views/layout/HelpLayer/style.css
@@ -1,6 +1,6 @@
 #HelpLayer svg {
   position: absolute;
-  z-index: 10;
+  z-index: 110;
   left: 0px;
   top: 0px;
   width: 100%;
@@ -37,7 +37,7 @@
   position: absolute;
   bottom: 2em;
   right: 2em;
-  z-index: 11;
+  z-index: 111;
   padding: 1em;
   background-color: white;
   border: 1px solid rgba(0,0,0,0.2);

--- a/app/resonant-laboratory/views/layout/Overlay/style.css
+++ b/app/resonant-laboratory/views/layout/Overlay/style.css
@@ -3,7 +3,7 @@
   width: 100%;
   height: 100%;
   background-color: rgba(0,0,0,0.35);
-  z-index: 8;
+  z-index: 108;
   overflow: auto;
 }
 


### PR DESCRIPTION
Fixes #228.

This allows visualizations (like upset) to use z-index within their visualizations (up to a value of 100 which seems reasonable).

I had trouble reproducing the error of the floating div on my machine. It looks like the floating div is meant for taking care of the fade-in of the interface, then is supposed to be transparent, but apparently it sticks around sometime. @alex-r-bigelow I know I've seen it on your machine if you want to verify it fails before this branch but works after applying this.