### PR TITLE
Handle empty data in UpSet

### DIFF
--- a/src/candela/components/UpSet/index.js
+++ b/src/candela/components/UpSet/index.js
@@ -55,6 +55,9 @@ export default class UpSet {
     if (!this.options.id || (!this.options.sets && !this.options.fields)) {
       return;
     }
+    if (!this.options.data || this.options.data.length === 0) {
+      return;
+    }
 
     d3.select(this.el).html(template);
 


### PR DESCRIPTION
Fixes #248. The underlying UpSet code does not seem to handle empty data well, and when loading an UpSet visualization directly from a project settings (e.g. refreshing a page) ResLab attempts to render with empty data before the data arrives asynchronously.

This fixes the issue by not rendering UpSet until data is available, which is appropriate since UpSet breaks on empty data.