### PR TITLE
Visualization serialization

### DIFF
--- a/app/examples/custom/serialize/index.jade
+++ b/app/examples/custom/serialize/index.jade
@@ -1,0 +1,3 @@
+#vis-element
+#serialize-links
+a#download-link

--- a/app/examples/custom/serialize/index.js
+++ b/app/examples/custom/serialize/index.js
@@ -1,0 +1,40 @@
+import candela from './../../../../src/candela';
+import iris from './../../data/iris.json';
+
+let el = document.getElementById('vis-element');
+let vis = new candela.components.ScatterPlot(el, {
+  data: iris,
+  x: 'petalLength',
+  y: 'petalWidth',
+  color: 'sepalLength',
+  shape: 'species',
+  width: 620,
+  height: 500
+});
+
+// Attempt serialize() before render().
+if (vis.serialize) {
+  vis.serialize('png').then(() => {
+    throw new Error('serialize() should not be allowed before render()');
+  }).catch(msg => {
+    console.log('Yay! serialize() was correctly rejected with the message: ' + msg);
+  });
+}
+
+vis.render();
+
+// Create download links for serializable charts
+let download = document.getElementById('download-link');
+let serialize = document.getElementById('serialize-links');
+vis.serializationFormats.forEach(format => {
+  let element = document.createElement('button');
+  element.innerHTML = format;
+  element.addEventListener('click', () => {
+    vis.serialize(format).then(value => {
+      download.setAttribute('download', 'chart.' + format);
+      download.setAttribute('href', value);
+      download.click();
+    });
+  }, false);
+  serialize.appendChild(element);
+});

--- a/app/examples/index.js
+++ b/app/examples/index.js
@@ -81,11 +81,11 @@ function showPage () {
       // Create download links for serializable charts
       let download = document.getElementById('download-link');
       let serialize = document.getElementById('serialize-links');
-      vis.getSerializationFormats().forEach((format) => {
+      vis.getSerializationFormats().forEach(format => {
         let element = document.createElement('button');
         element.innerHTML = format;
-        element.addEventListener('click', function () {
-          vis.serialize(format).then((value) => {
+        element.addEventListener('click', () => {
+          vis.serialize(format).then(value => {
             download.setAttribute('download', 'chart.' + format);
             download.setAttribute('href', value);
             download.click();

--- a/app/examples/index.js
+++ b/app/examples/index.js
@@ -88,6 +88,7 @@ function showPage () {
 
       vis.render();
 
+      /*
       // Create download links for serializable charts
       let download = document.getElementById('download-link');
       let serialize = document.getElementById('serialize-links');
@@ -103,6 +104,7 @@ function showPage () {
         }, false);
         serialize.appendChild(element);
       });
+      */
 
       window.addResizeListener(el, () => vis.render());
     }

--- a/app/examples/index.js
+++ b/app/examples/index.js
@@ -91,7 +91,7 @@ function showPage () {
       // Create download links for serializable charts
       let download = document.getElementById('download-link');
       let serialize = document.getElementById('serialize-links');
-      vis.getSerializationFormats().forEach(format => {
+      vis.serializationFormats.forEach(format => {
         let element = document.createElement('button');
         element.innerHTML = format;
         element.addEventListener('click', () => {

--- a/app/examples/index.js
+++ b/app/examples/index.js
@@ -77,6 +77,23 @@ function showPage () {
       }
       let vis = new candela.components[properties.component](el, properties.options);
       vis.render();
+
+      // Create download links for serializable charts
+      let download = document.getElementById('download-link');
+      let serialize = document.getElementById('serialize-links');
+      vis.getSerializationFormats().forEach((format) => {
+        let element = document.createElement('button');
+        element.innerHTML = format;
+        element.addEventListener('click', function () {
+          vis.serialize(format).then((value) => {
+            download.setAttribute('download', 'chart.' + format);
+            download.setAttribute('href', value);
+            download.click();
+          });
+        }, false);
+        serialize.appendChild(element);
+      });
+
       window.addResizeListener(el, () => vis.render());
     }
   }

--- a/app/examples/index.js
+++ b/app/examples/index.js
@@ -76,6 +76,16 @@ function showPage () {
         properties.options.data = datasets[properties.options.data];
       }
       let vis = new candela.components[properties.component](el, properties.options);
+
+      // Attempt serialize() before render().
+      if (vis.serialize) {
+        vis.serialize('png').then(() => {
+          throw new Error('serialize() should not be allowed before render()');
+        }).catch(msg => {
+          console.log('Yay! serialize() was correctly rejected with the message: ' + msg);
+        });
+      }
+
       vis.render();
 
       // Create download links for serializable charts

--- a/app/examples/index.js
+++ b/app/examples/index.js
@@ -62,6 +62,12 @@ function showPage () {
           require('./custom/dynamic-linechart/index.js');
           break;
 
+        case 'serialize':
+          customTemplate = require('./custom/serialize/index.jade');
+          document.getElementsByTagName('body')[0].innerHTML = customTemplate(properties);
+          require('./custom/serialize/index.js');
+          break;
+
         default:
           console.log(`unregistered custom example: ${properties.template}`);
           break;
@@ -76,36 +82,7 @@ function showPage () {
         properties.options.data = datasets[properties.options.data];
       }
       let vis = new candela.components[properties.component](el, properties.options);
-
-      // Attempt serialize() before render().
-      if (vis.serialize) {
-        vis.serialize('png').then(() => {
-          throw new Error('serialize() should not be allowed before render()');
-        }).catch(msg => {
-          console.log('Yay! serialize() was correctly rejected with the message: ' + msg);
-        });
-      }
-
       vis.render();
-
-      /*
-      // Create download links for serializable charts
-      let download = document.getElementById('download-link');
-      let serialize = document.getElementById('serialize-links');
-      vis.serializationFormats.forEach(format => {
-        let element = document.createElement('button');
-        element.innerHTML = format;
-        element.addEventListener('click', () => {
-          vis.serialize(format).then(value => {
-            download.setAttribute('download', 'chart.' + format);
-            download.setAttribute('href', value);
-            download.click();
-          });
-        }, false);
-        serialize.appendChild(element);
-      });
-      */
-
       window.addResizeListener(el, () => vis.render());
     }
   }

--- a/app/examples/index.styl
+++ b/app/examples/index.styl
@@ -46,3 +46,11 @@ text:not(.fontawe)
 
 #vis-element
     overflow hidden
+
+#serialize-links
+    position fixed
+    right 30px
+    bottom 30px
+
+#download-link
+    visibility hidden

--- a/app/examples/index.styl
+++ b/app/examples/index.styl
@@ -11,6 +11,10 @@ html, body, .page
 .vis-table
     height 300px
 
+.vis-full
+    width 100%
+    height 100%
+
 .containing-matrix
     width 100%
 

--- a/app/examples/index.styl
+++ b/app/examples/index.styl
@@ -11,10 +11,6 @@ html, body, .page
 .vis-table
     height 300px
 
-.vis-full
-    width 100%
-    height 100%
-
 .containing-matrix
     width 100%
 
@@ -46,11 +42,6 @@ text:not(.fontawe)
 
 #vis-element
     overflow hidden
-
-#serialize-links
-    position fixed
-    right 30px
-    bottom 30px
 
 #download-link
     visibility hidden

--- a/app/examples/vis.jade
+++ b/app/examples/vis.jade
@@ -1,4 +1,4 @@
 .page
-  #vis-container
+  #vis-container.vis-full
   #serialize-links
   a#download-link

--- a/app/examples/vis.jade
+++ b/app/examples/vis.jade
@@ -1,2 +1,4 @@
 .page
   #vis-container.vis-full
+  #serialize-links
+  a#download-link

--- a/app/examples/vis.jade
+++ b/app/examples/vis.jade
@@ -1,4 +1,2 @@
 .page
   #vis-container.vis-full
-  #serialize-links
-  a#download-link

--- a/app/examples/vis.jade
+++ b/app/examples/vis.jade
@@ -1,4 +1,4 @@
 .page
-  #vis-container.vis-full
+  #vis-container
   #serialize-links
   a#download-link

--- a/app/examples/visualizations.json
+++ b/app/examples/visualizations.json
@@ -293,5 +293,10 @@
     "hash": "dynamic-linechart",
     "name": "Dynamic Line Chart",
     "template": "dynamic-linechart"
+  },
+  {
+    "hash": "serialize",
+    "name": "Serialization",
+    "template": "serialize"
   }
 ]

--- a/src/candela/VisComponent/README.md
+++ b/src/candela/VisComponent/README.md
@@ -27,19 +27,6 @@ is declared as an extension of ``VisComponent``):
 2. The component should report its expected inputs in
    [MyComponent.spec](#viscomponentspec).
 
-## new MyComponent(el, options)
-
-**Note**: The constructor for the abstract superclass is empty. You should use
-the constructor for specific subclasses of VisComponent.
-
-* **el** is a valid container for the visualization. The container will often be
-  a DOM element such as `<div>`, but may need to be another type for certain
-  visualizations.
-
-* **options** is an object containing the initial options for the visualization.
-  This includes any data, visual matchings, or other settings pertinent to the
-  visualization. Options are specified in the form `{name: value}`.
-
 ## MyComponent.spec
 
 The `spec` field is a static property on the component's class which describes
@@ -72,3 +59,31 @@ an object with the following properties:
 | mode        | String | The domain mode, one of `'choice'` or `'field'`. The `'choice'` mode will allow a fixed set of options set in the `'from'` field. The `'field'` mode will allow a field or list of fields from another input. If the option type is `'string'`, the option is a single field, and if the option type is `'string_list'`, the option accepts a list of fields. |
 | from        | Array or String | If the mode is `'choice'`, it is the list of strings to use as a dropdown. If the mode is `'field'`, it is the name of the input from which to extract fields.
 | fieldTypes  | Array of String | If mode is `'field'`, this specifies the types of fields to support. This array may contain any combination of [datalib's supported field types](https://github.com/vega/datalib/wiki/Import#dl_type_infer) which include `'string'`, `'date'`, `'number'`, `'integer'`, and `'boolean'`. |
+
+## component = new MyComponent(el, options)
+
+**Note**: The constructor for the abstract superclass is empty. You should use
+the constructor for specific subclasses of VisComponent.
+
+* **el** is a valid container for the visualization. The container will often be
+  a DOM element such as `<div>`, but may need to be another type for certain
+  visualizations.
+
+* **options** is an object containing the initial options for the visualization.
+  This includes any data, visual matchings, or other settings pertinent to the
+  visualization. Options are specified in the form `{name: value}`.
+
+## component.serializationFormats
+
+The `serializationFormats` field is a list of strings of supported formats.
+Formats include:
+
+* `'png'`: A base64-encoded string for a PNG image. This string may be placed in the
+`src` attribute of an `<img>` element to show the image.
+
+* `'svg'`: A base64-encoded string for an SVG scene. This string may be placed in the
+`src` attribute of an `<img>` element to show the image.
+
+## component.serialize(format)
+
+Serializes the component into the specified **format**.

--- a/src/candela/VisComponent/index.js
+++ b/src/candela/VisComponent/index.js
@@ -10,4 +10,8 @@ export default class VisComponent {
   render () {
     throw new Error('"render() is pure abstract"');
   }
+
+  getSerializationFormats () {
+    return [];
+  }
 }

--- a/src/candela/VisComponent/index.js
+++ b/src/candela/VisComponent/index.js
@@ -11,7 +11,7 @@ export default class VisComponent {
     throw new Error('"render() is pure abstract"');
   }
 
-  getSerializationFormats () {
+  get serializationFormats () {
     return [];
   }
 }

--- a/src/candela/VisComponent/mixin/VegaChart.js
+++ b/src/candela/VisComponent/mixin/VegaChart.js
@@ -1,0 +1,27 @@
+import vega from '../../util/vega';
+
+let VegaChart = (Base, spec) => class extends Base {
+  constructor (...args) {
+    super(...args);
+    this.options = args[1];
+  }
+
+  render () {
+    this.chart = vega.parseChart(spec, this.el, this.options);
+  }
+
+  get serializationFormats () {
+    return ['png', 'svg'];
+  }
+
+  serialize (format) {
+    if (!this.chart) {
+      return Promise.reject('The render() method must be called before serialize().');
+    }
+    return this.chart.then(vobj => {
+      return vobj.toImageURL(format);
+    });
+  }
+};
+
+export default VegaChart;

--- a/src/candela/components/BarChart/index.js
+++ b/src/candela/components/BarChart/index.js
@@ -1,8 +1,8 @@
 import VisComponent from '../../VisComponent';
-import vega from '../../util/vega';
+import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
-export default class BarChart extends VisComponent {
+export default class BarChart extends VegaChart(VisComponent, spec) {
   static get spec () {
     return {
       options: [
@@ -55,14 +55,5 @@ export default class BarChart extends VisComponent {
         }
       ]
     };
-  }
-
-  constructor (el, options) {
-    super(el);
-    this.options = options;
-  }
-
-  render () {
-    vega.parseChart(spec, this.el, this.options);
   }
 }

--- a/src/candela/components/BoxPlot/index.js
+++ b/src/candela/components/BoxPlot/index.js
@@ -1,8 +1,8 @@
 import VisComponent from '../../VisComponent';
-import vega from '../../util/vega';
+import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
-export default class BoxPlot extends VisComponent {
+export default class BoxPlot extends VegaChart(VisComponent, spec) {
   static get spec () {
     return {
       options: [
@@ -34,14 +34,5 @@ export default class BoxPlot extends VisComponent {
         }
       ]
     };
-  }
-
-  constructor (el, options) {
-    super(el);
-    this.options = options;
-  }
-
-  render () {
-    vega.parseChart(spec, this.el, this.options);
   }
 }

--- a/src/candela/components/BulletChart/index.js
+++ b/src/candela/components/BulletChart/index.js
@@ -1,8 +1,8 @@
 import VisComponent from '../../VisComponent';
-import vega from '../../util/vega';
+import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
-export default class BulletChart extends VisComponent {
+export default class BulletChart extends VegaChart(VisComponent, spec) {
   static get options () {
     return [
       {
@@ -35,14 +35,5 @@ export default class BulletChart extends VisComponent {
         optional: true
       }
     ];
-  }
-
-  constructor (el, options) {
-    super(el);
-    this.options = options;
-  }
-
-  render () {
-    vega.parseChart(spec, this.el, this.options);
   }
 }

--- a/src/candela/components/GanttChart/index.js
+++ b/src/candela/components/GanttChart/index.js
@@ -1,8 +1,8 @@
 import VisComponent from '../../VisComponent';
-import vega from '../../util/vega';
+import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
-export default class GanttChart extends VisComponent {
+export default class GanttChart extends VegaChart(VisComponent, spec) {
   static get spec () {
     return {
       options: [
@@ -53,14 +53,5 @@ export default class GanttChart extends VisComponent {
         }
       ]
     };
-  }
-
-  constructor (el, options) {
-    super(el);
-    this.options = options;
-  }
-
-  render () {
-    vega.parseChart(spec, this.el, this.options);
   }
 }

--- a/src/candela/components/Heatmap/index.js
+++ b/src/candela/components/Heatmap/index.js
@@ -1,8 +1,8 @@
 import VisComponent from '../../VisComponent';
-import vega from '../../util/vega';
+import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
-export default class Heatmap extends VisComponent {
+export default class Heatmap extends VegaChart(VisComponent, spec) {
   static get spec () {
     return {
       options: [
@@ -45,15 +45,5 @@ export default class Heatmap extends VisComponent {
         }
       ]
     };
-  }
-
-  constructor (el, options) {
-    super(el);
-    this.options = options;
-    this.render();
-  }
-
-  render () {
-    vega.parseChart(spec, this.el, this.options);
   }
 }

--- a/src/candela/components/Histogram/index.js
+++ b/src/candela/components/Histogram/index.js
@@ -1,8 +1,8 @@
 import VisComponent from '../../VisComponent';
-import vega from '../../util/vega';
+import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
-export default class Histogram extends VisComponent {
+export default class Histogram extends VegaChart(VisComponent, spec) {
   static get spec () {
     return {
       options: [
@@ -34,14 +34,5 @@ export default class Histogram extends VisComponent {
         }
       ]
     };
-  }
-
-  constructor (el, options) {
-    super(el);
-    this.options = options;
-  }
-
-  render () {
-    vega.parseChart(spec, this.el, this.options);
   }
 }

--- a/src/candela/components/LineChart/index.js
+++ b/src/candela/components/LineChart/index.js
@@ -1,8 +1,8 @@
 import VisComponent from '../../VisComponent';
-import vega from '../../util/vega';
+import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
-export default class LineChart extends VisComponent {
+export default class LineChart extends VegaChart(VisComponent, spec) {
   static get spec () {
     return {
       options: [
@@ -33,14 +33,5 @@ export default class LineChart extends VisComponent {
         }
       ]
     };
-  }
-
-  constructor (el, options) {
-    super(el);
-    this.options = options;
-  }
-
-  render () {
-    vega.parseChart(spec, this.el, this.options);
   }
 }

--- a/src/candela/components/ScatterPlot/index.js
+++ b/src/candela/components/ScatterPlot/index.js
@@ -85,6 +85,19 @@ export default class ScatterPlot extends VisComponent {
   }
 
   render () {
-    vega.parseChart(spec, this.el, this.options);
+    this.chart = vega.parseChart(spec, this.el, this.options);
+  }
+
+  getSerializationFormats () {
+    return ['png', 'svg'];
+  }
+
+  serialize (format) {
+    if (!this.chart) {
+      this.render();
+    }
+    return this.chart.then((vobj) => {
+      return vobj.toImageURL(format);
+    });
   }
 }

--- a/src/candela/components/ScatterPlot/index.js
+++ b/src/candela/components/ScatterPlot/index.js
@@ -1,8 +1,8 @@
 import VisComponent from '../../VisComponent';
-import vega from '../../util/vega';
+import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
-export default class ScatterPlot extends VisComponent {
+export default class ScatterPlot extends VegaChart(VisComponent, spec) {
   static get spec () {
     return {
       options: [
@@ -77,27 +77,5 @@ export default class ScatterPlot extends VisComponent {
         }
       ]
     };
-  }
-
-  constructor (el, options) {
-    super(el);
-    this.options = options;
-  }
-
-  render () {
-    this.chart = vega.parseChart(spec, this.el, this.options);
-  }
-
-  get serializationFormats () {
-    return ['png', 'svg'];
-  }
-
-  serialize (format) {
-    if (!this.chart) {
-      return Promise.reject('The render() method must be called before serialize().');
-    }
-    return this.chart.then(vobj => {
-      return vobj.toImageURL(format);
-    });
   }
 }

--- a/src/candela/components/ScatterPlot/index.js
+++ b/src/candela/components/ScatterPlot/index.js
@@ -88,7 +88,7 @@ export default class ScatterPlot extends VisComponent {
     this.chart = vega.parseChart(spec, this.el, this.options);
   }
 
-  getSerializationFormats () {
+  get serializationFormats () {
     return ['png', 'svg'];
   }
 

--- a/src/candela/components/ScatterPlot/index.js
+++ b/src/candela/components/ScatterPlot/index.js
@@ -94,7 +94,7 @@ export default class ScatterPlot extends VisComponent {
 
   serialize (format) {
     if (!this.chart) {
-      this.render();
+      return Promise.reject('The render() method must be called before serialize().');
     }
     return this.chart.then(vobj => {
       return vobj.toImageURL(format);

--- a/src/candela/components/ScatterPlot/index.js
+++ b/src/candela/components/ScatterPlot/index.js
@@ -96,7 +96,7 @@ export default class ScatterPlot extends VisComponent {
     if (!this.chart) {
       this.render();
     }
-    return this.chart.then((vobj) => {
+    return this.chart.then(vobj => {
       return vobj.toImageURL(format);
     });
   }

--- a/src/candela/components/ScatterPlotMatrix/index.js
+++ b/src/candela/components/ScatterPlotMatrix/index.js
@@ -1,8 +1,8 @@
 import VisComponent from '../../VisComponent';
-import vega from '../../util/vega';
+import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
-export default class ScatterPlotMatrix extends VisComponent {
+export default class ScatterPlotMatrix extends VegaChart(VisComponent, spec) {
   static get spec () {
     return {
       options: [
@@ -34,14 +34,5 @@ export default class ScatterPlotMatrix extends VisComponent {
         }
       ]
     };
-  }
-
-  constructor (el, options) {
-    super(el);
-    this.options = options;
-  }
-
-  render () {
-    vega.parseChart(spec, this.el, this.options);
   }
 }


### PR DESCRIPTION
This is an initial serialization prototype. `getSerializationFormats()` provides a list of serialization types, which may be sent to `serialize()`.

The examples page will produce buttons for downloading each serialization type supported by the visualization. Currently only works with the scatterplot example.