### PR TITLE
Split spec into options and container getters

### DIFF
--- a/app/resonant-laboratory/views/overlays/VisualizationLibrary/index.js
+++ b/app/resonant-laboratory/views/overlays/VisualizationLibrary/index.js
@@ -8,16 +8,16 @@ let VisualizationLibrary = Backbone.View.extend({
   render: function () {
     this.$el.html(myTemplate);
 
-    // For any candela vis that has a spec defined, extract
+    // For any candela vis that has options defined, extract
     // field options for our matching options.
     // TODO: We also need to extract data options - we currently
     // assume that there will be one table option called "data".
     let libraryVisSpecs = [];
     for (let visName of Object.keys(candela.components)) {
-      if (candela.components[visName].spec) {
+      if (candela.components[visName].options) {
         let spec = {
           name: visName,
-          options: candela.components[visName].spec.options.filter(option => {
+          options: candela.components[visName].options.filter(option => {
             return option.domain && option.domain.mode === 'field';
           })
         };

--- a/src/candela/VisComponent/README.md
+++ b/src/candela/VisComponent/README.md
@@ -5,37 +5,33 @@ The base class for Candela visualization components.
 This class is intentionally minimal, because there are only a few common
 features of all Candela components:
 
-1. Candela components work on the web, so the constructor looks like ``new
-   VisComponent(el)``, where ``el`` is (usually) a DOM element. The
-   ``VisComponent`` constructor attaches ``el`` to the object, so you can always
-   refer to it using ``this.el``.
+1. Candela components work on the web, so the constructor looks like `new
+   VisComponent(el)`, where `el` is (usually) a DOM element. The
+   `VisComponent` constructor attaches `el` to the object, so you can always
+   refer to it using `this.el`.
 
 2. Candela components perform some type of visualization, so they have a
-   ``render()`` method. The ``VisComponent`` ``render()`` method simply throws
-   an exception; if you truly want your component to do nothing when it renders,
-   simply redefine the method to be a no-op.
+   [`render()`](#componentrender) method. The base class [`render()`](#componentrender)
+   is not implemented and raises an exception.
 
-You can create a concrete visualization component by extending ``VisComponent``.
+You can create a concrete visualization component by extending `VisComponent`.
 The following best practices maximize clarity, reusability, and interoperability
-of your components (in the rest of this document, imagine that ``MyComponent``
-is declared as an extension of ``VisComponent``):
+of your components (in the rest of this document, imagine that `MyComponent`
+is declared as an extension of `VisComponent`, such as `BarChart`):
 
 1. The constructor should take an [additional parameter
-   ``options``](#new-mycomponentel-options) encapsulating all runtime options
-   for the component.
+   `options`](#component-new-mycomponentel-options) encapsulating all
+   runtime options for the component.
 
 2. The component should report its expected inputs in
-   [MyComponent.spec](#viscomponentspec).
+   [MyComponent.options](#mycomponentoptions).
 
-## MyComponent.spec
+## MyComponent.options
 
-The `spec` field is a static property on the component's class which describes
-how to set up the visualization.
-
-| Property    | Type   | Description  |
-| :--------   | :----- | :----------- |
-| container   | Class  | Optional. The type of container this visualization can be added to. Default is DOMElement if unset. |
-| options     | Array of [Option](#option-specification) | A specification of options needed for this visualization. This is used to introspect the component to implement features such as automatic UI building. |
+This static property is an array of [Options](#option-specification), containing
+a specification of options this visualization accepts.
+This may be used to introspect the component to implement features such as
+automatic UI building.
 
 ### Option Specification
 
@@ -60,10 +56,14 @@ an object with the following properties:
 | from        | Array or String | If the mode is `'choice'`, it is the list of strings to use as a dropdown. If the mode is `'field'`, it is the name of the input from which to extract fields.
 | fieldTypes  | Array of String | If mode is `'field'`, this specifies the types of fields to support. This array may contain any combination of [datalib's supported field types](https://github.com/vega/datalib/wiki/Import#dl_type_infer) which include `'string'`, `'date'`, `'number'`, `'integer'`, and `'boolean'`. |
 
+## MyComponent.container
+
+A static field containing the type of container this visualization can be added to.
+The most common is DOMElement.
+
 ## component = new MyComponent(el, options)
 
-**Note**: The constructor for the abstract superclass is empty. You should use
-the constructor for specific subclasses of VisComponent.
+Constructs a new instance of the candela component.
 
 * **el** is a valid container for the visualization. The container will often be
   a DOM element such as `<div>`, but may need to be another type for certain
@@ -73,17 +73,31 @@ the constructor for specific subclasses of VisComponent.
   This includes any data, visual matchings, or other settings pertinent to the
   visualization. Options are specified in the form `{name: value}`.
 
+**Note**: The constructor for the abstract superclass is empty. You should use
+the constructor for specific subclasses of `VisComponent`.
+
+## component.render()
+
+Renders the component to it's container using the current set of options.
+
+**Note**: The `VisComponent` `render()` method simply throws
+an exception; if you truly want your component to do nothing when it renders,
+simply redefine the method to be a no-op.
+
 ## component.serializationFormats
 
 The `serializationFormats` field is a list of strings of supported formats.
 Formats include:
 
-* `'png'`: A base64-encoded string for a PNG image. This string may be placed in the
+* `'png'`: A base64-encoded string for a PNG image. The string may be placed in the
 `src` attribute of an `<img>` element to show the image.
 
-* `'svg'`: A base64-encoded string for an SVG scene. This string may be placed in the
+* `'svg'`: A base64-encoded string for an SVG scene. The string may be placed in the
 `src` attribute of an `<img>` element to show the image.
 
 ## component.serialize(format)
 
 Serializes the component into the specified **format**.
+
+**Note**: [`render()`](#componentrender) must be called at least once
+before serialize() is called.

--- a/src/candela/VisComponent/README.md
+++ b/src/candela/VisComponent/README.md
@@ -20,7 +20,7 @@ of your components (in the rest of this document, imagine that `MyComponent`
 is declared as an extension of `VisComponent`, such as `BarChart`):
 
 1. The constructor should take an [additional parameter
-   `options`](#component-new-mycomponentel-options) encapsulating all
+   `options`](#component--new-mycomponentel-options) encapsulating all
    runtime options for the component.
 
 2. The component should report its expected inputs in

--- a/src/candela/VisComponent/README.md
+++ b/src/candela/VisComponent/README.md
@@ -12,7 +12,7 @@ features of all Candela components:
 
 2. Candela components perform some type of visualization, so they have a
    [`render()`](#componentrender) method. The base class [`render()`](#componentrender)
-   is not implemented and raises an exception.
+   simply raises an exception.
 
 You can create a concrete visualization component by extending `VisComponent`.
 The following best practices maximize clarity, reusability, and interoperability
@@ -98,6 +98,3 @@ Formats include:
 ## component.serialize(format)
 
 Serializes the component into the specified **format**.
-
-**Note**: [`render()`](#componentrender) must be called at least once
-before serialize() is called.

--- a/src/candela/components/BarChart/index.js
+++ b/src/candela/components/BarChart/index.js
@@ -3,57 +3,55 @@ import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
 export default class BarChart extends VegaChart(VisComponent, spec) {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'x',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'y',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'color',
-          type: 'string',
-          format: 'text',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'hover',
-          type: 'string_list',
-          format: 'string_list',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'x',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'y',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'color',
+        type: 'string',
+        format: 'text',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'hover',
+        type: 'string_list',
+        format: 'string_list',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      }
+    ];
   }
 }

--- a/src/candela/components/BoxPlot/index.js
+++ b/src/candela/components/BoxPlot/index.js
@@ -3,36 +3,34 @@ import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
 export default class BoxPlot extends VegaChart(VisComponent, spec) {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'fields',
-          type: 'string_list',
-          format: 'string_list',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'group',
-          type: 'string',
-          format: 'text',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'fields',
+        type: 'string_list',
+        format: 'string_list',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['date', 'number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'group',
+        type: 'string',
+        format: 'text',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      }
+    ];
   }
 }

--- a/src/candela/components/GanttChart/index.js
+++ b/src/candela/components/GanttChart/index.js
@@ -3,55 +3,53 @@ import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
 export default class GanttChart extends VegaChart(VisComponent, spec) {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'label',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'level',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'start',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'end',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['number', 'integer', 'boolean']
-          }
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'label',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'level',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'start',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'end',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['number', 'integer', 'boolean']
+        }
+      }
+    ];
   }
 }

--- a/src/candela/components/Heatmap/index.js
+++ b/src/candela/components/Heatmap/index.js
@@ -3,47 +3,45 @@ import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
 export default class Heatmap extends VegaChart(VisComponent, spec) {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'id',
-          type: 'string',
-          format: 'text',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'fields',
-          type: 'string_list',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'sort',
-          type: 'string',
-          format: 'text',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'id',
+        type: 'string',
+        format: 'text',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'fields',
+        type: 'string_list',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'sort',
+        type: 'string',
+        format: 'text',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      }
+    ];
   }
 }

--- a/src/candela/components/Histogram/index.js
+++ b/src/candela/components/Histogram/index.js
@@ -3,36 +3,34 @@ import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
 export default class Histogram extends VegaChart(VisComponent, spec) {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'bin',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'aggregate',
-          type: 'string',
-          format: 'text',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['number', 'integer', 'boolean']
-          }
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'bin',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'aggregate',
+        type: 'string',
+        format: 'text',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['number', 'integer', 'boolean']
+        }
+      }
+    ];
   }
 }

--- a/src/candela/components/LineChart/index.js
+++ b/src/candela/components/LineChart/index.js
@@ -3,35 +3,33 @@ import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
 export default class LineChart extends VegaChart(VisComponent, spec) {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'x',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'y',
-          type: 'string_list',
-          format: 'string_list',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['date', 'number', 'integer', 'boolean']
-          }
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'x',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['date', 'number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'y',
+        type: 'string_list',
+        format: 'string_list',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['date', 'number', 'integer', 'boolean']
+        }
+      }
+    ];
   }
 }

--- a/src/candela/components/LineUp/index.js
+++ b/src/candela/components/LineUp/index.js
@@ -7,44 +7,42 @@ import './index.styl';
 import 'font-awesome-webpack';
 
 export default class LineUp {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'fields',
-          type: 'string_list',
-          format: 'string_list',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'stacked',
-          type: 'boolean',
-          format: 'boolean',
-          optional: true
-        },
-        {
-          name: 'histograms',
-          type: 'boolean',
-          format: 'boolean',
-          optional: true
-        },
-        {
-          name: 'animation',
-          type: 'boolean',
-          format: 'boolean',
-          optional: true
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'fields',
+        type: 'string_list',
+        format: 'string_list',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'stacked',
+        type: 'boolean',
+        format: 'boolean',
+        optional: true
+      },
+      {
+        name: 'histograms',
+        type: 'boolean',
+        format: 'boolean',
+        optional: true
+      },
+      {
+        name: 'animation',
+        type: 'boolean',
+        format: 'boolean',
+        optional: true
+      }
+    ];
   }
 
   constructor (el, options) {

--- a/src/candela/components/LineUp/test/lineup.js
+++ b/src/candela/components/LineUp/test/lineup.js
@@ -10,7 +10,7 @@ import LineUp from '..';
 test('LineUp component', t => {
   $('body').append($('<div/>').attr({id: 'elem'}).css({width: 800, height: 600}));
   t.ok(LineUp, 'LineUp exists');
-  t.ok(LineUp.spec.options, 'LineUp spec exists');
+  t.ok(LineUp.options, 'LineUp options exists');
   let lu = new LineUp('#elem', {
     data: [
       {a: 1, b: 2, c: 'a', d: true},

--- a/src/candela/components/ScatterPlot/index.js
+++ b/src/candela/components/ScatterPlot/index.js
@@ -3,79 +3,77 @@ import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
 export default class ScatterPlot extends VegaChart(VisComponent, spec) {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'x',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'y',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'size',
-          type: 'string',
-          format: 'text',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'shape',
-          type: 'string',
-          format: 'text',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'color',
-          type: 'string',
-          format: 'text',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'hover',
-          type: 'string_list',
-          format: 'string_list',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'x',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['date', 'number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'y',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['date', 'number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'size',
+        type: 'string',
+        format: 'text',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'shape',
+        type: 'string',
+        format: 'text',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'color',
+        type: 'string',
+        format: 'text',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'hover',
+        type: 'string_list',
+        format: 'string_list',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      }
+    ];
   }
 }

--- a/src/candela/components/ScatterPlotMatrix/index.js
+++ b/src/candela/components/ScatterPlotMatrix/index.js
@@ -3,36 +3,34 @@ import VegaChart from '../../VisComponent/mixin/VegaChart';
 import spec from './spec.json';
 
 export default class ScatterPlotMatrix extends VegaChart(VisComponent, spec) {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'fields',
-          type: 'string_list',
-          format: 'string_list',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'color',
-          type: 'string',
-          format: 'text',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'fields',
+        type: 'string_list',
+        format: 'string_list',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'color',
+        type: 'string',
+        format: 'text',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      }
+    ];
   }
 }

--- a/src/candela/components/UpSet/index.js
+++ b/src/candela/components/UpSet/index.js
@@ -4,58 +4,56 @@ import * as upset from 'UpSet';
 import template from './template.html';
 
 export default class UpSet {
-  static get spec () {
-    return {
-      options: [
-        {
-          name: 'data',
-          type: 'table',
-          format: 'objectlist'
-        },
-        {
-          name: 'id',
-          type: 'string',
-          format: 'text',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'sets',
-          type: 'string_list',
-          format: 'string_list',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['integer', 'boolean', 'string']
-          }
-        },
-        {
-          name: 'fields',
-          type: 'string_list',
-          format: 'string_list',
-          optional: true,
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
-        },
-        {
-          name: 'metadata',
-          type: 'string_list',
-          format: 'string_list',
-          domain: {
-            mode: 'field',
-            from: 'data',
-            fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
-          }
+  static get options () {
+    return [
+      {
+        name: 'data',
+        type: 'table',
+        format: 'objectlist'
+      },
+      {
+        name: 'id',
+        type: 'string',
+        format: 'text',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
         }
-      ]
-    };
+      },
+      {
+        name: 'sets',
+        type: 'string_list',
+        format: 'string_list',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['integer', 'boolean', 'string']
+        }
+      },
+      {
+        name: 'fields',
+        type: 'string_list',
+        format: 'string_list',
+        optional: true,
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      },
+      {
+        name: 'metadata',
+        type: 'string_list',
+        format: 'string_list',
+        domain: {
+          mode: 'field',
+          from: 'data',
+          fieldTypes: ['string', 'date', 'number', 'integer', 'boolean']
+        }
+      }
+    ];
   }
 
   constructor (el, options) {


### PR DESCRIPTION
There are currently no container getters (all are assumed to be divs) so this simply replaces `vis.spec.options` with `vis.options`. I updated ResLab to work with this change.