### PR TITLE
[WIP] Custom filesystem assetstore adapter

### DIFF
--- a/app/resonant-laboratory/models/Dataset.js
+++ b/app/resonant-laboratory/models/Dataset.js
@@ -115,6 +115,7 @@ let Dataset = MetadataItem.extend({
           data: {
             extraParameters: JSON.stringify({
               fileType: 'csv',
+              outputType: 'csv',
               offset: 47,
               limit: 5
             })

--- a/app/resonant-laboratory/models/Dataset.js
+++ b/app/resonant-laboratory/models/Dataset.js
@@ -114,6 +114,7 @@ let Dataset = MetadataItem.extend({
           path: 'item/' + this.getId() + '/download',
           data: {
             extraParameters: JSON.stringify({
+              fileType: 'csv',
               offset: 47,
               limit: 5
             })

--- a/app/resonant-laboratory/models/Dataset.js
+++ b/app/resonant-laboratory/models/Dataset.js
@@ -112,6 +112,12 @@ let Dataset = MetadataItem.extend({
       }, () => {
         return girder.restRequest({
           path: 'item/' + this.getId() + '/download',
+          data: {
+            extraParameters: JSON.stringify({
+              offset: 47,
+              limit: 5
+            })
+          },
           type: 'GET',
           error: null,
           dataType: 'text'

--- a/app/resonant-laboratory/server/SemanticFilesystemAssetstoreAdapter.py
+++ b/app/resonant-laboratory/server/SemanticFilesystemAssetstoreAdapter.py
@@ -4,6 +4,7 @@ import json
 import sys
 from girder.models.model_base import GirderException
 from girder.utility.filesystem_assetstore_adapter import FilesystemAssetstoreAdapter
+from girder.utility.gridfs_assetstore_adapter import GridFsAssetstoreAdapter
 
 
 class StreamFile(object):
@@ -172,3 +173,4 @@ def semantic_access(Cls):
     return NewCls
 
 SemanticFilesystemAssetstoreAdapter = semantic_access(FilesystemAssetstoreAdapter)
+SemanticGridFsAssetstoreAdapter = semantic_access(GridFsAssetstoreAdapter)

--- a/app/resonant-laboratory/server/SemanticFilesystemAssetstoreAdapter.py
+++ b/app/resonant-laboratory/server/SemanticFilesystemAssetstoreAdapter.py
@@ -19,6 +19,9 @@ class StreamFile(object):
     def flush(self):
         pass
 
+    def __iter__(self):
+        return self
+
     def next(self):
         if self.eof:
             raise StopIteration

--- a/app/resonant-laboratory/server/SemanticFilesystemAssetstoreAdapter.py
+++ b/app/resonant-laboratory/server/SemanticFilesystemAssetstoreAdapter.py
@@ -1,0 +1,10 @@
+from girder.utility.filesystem_assetstore_adapter import FilesystemAssetstoreAdapter
+
+
+class SemanticFilesystemAssetstoreAdapter(FilesystemAssetstoreAdapter):
+    def __init__(self, *args, **kwargs):
+        super(SemanticFilesystemAssetstoreAdapter, self).__init__(*args, **kwargs)
+
+    def downloadFile(self, *args, **kwargs):
+        print 'SemanticFSAA.downloadFile()'
+        return super(SemanticFilesystemAssetstoreAdapter, self).downloadFile(*args, **kwargs)

--- a/app/resonant-laboratory/server/SemanticFilesystemAssetstoreAdapter.py
+++ b/app/resonant-laboratory/server/SemanticFilesystemAssetstoreAdapter.py
@@ -1,3 +1,7 @@
+import csv
+import json
+import os
+from girder.models.model_base import GirderException
 from girder.utility.filesystem_assetstore_adapter import FilesystemAssetstoreAdapter
 
 
@@ -5,6 +9,44 @@ class SemanticFilesystemAssetstoreAdapter(FilesystemAssetstoreAdapter):
     def __init__(self, *args, **kwargs):
         super(SemanticFilesystemAssetstoreAdapter, self).__init__(*args, **kwargs)
 
-    def downloadFile(self, *args, **kwargs):
-        print 'SemanticFSAA.downloadFile()'
-        return super(SemanticFilesystemAssetstoreAdapter, self).downloadFile(*args, **kwargs)
+    def downloadFile(self, file, offset=0, headers=True, endByte=None,
+                     contentDisposition=None, extraParameters=None, **kwargs):
+        print 'extraParameters: %s' % (extraParameters)
+        if extraParameters is None:
+            return super(SemanticFilesystemAssetstoreAdapter, self).downloadFile(file, offset, headers, endByte, contentDisposition, extraParameters, **kwargs)
+
+        # TODO: for now, treat all special requests as being for a CSV file.
+        path = self.fullPath(file)
+
+        if not os.path.isfile(path):
+            raise GirderException(
+                'File %s does not exist.' % path,
+                'girder.utility.filesystem_assetstore_adapter.'
+                'file-does-not-exist')
+
+        extraParameters = json.loads(extraParameters)
+        offset = extraParameters.get('offset', 0)
+        limit = extraParameters.get('limit', 0)
+
+        def stream():
+            with open(path) as csvfile:
+                data = csv.reader(csvfile)
+
+                # Read and return the header line.
+                header_line = data.next()
+                yield ','.join(header_line) + '\n'
+
+                # Skip a number of lines equal to the offset parameter.
+                for i in range(offset):
+                    data.next()
+
+                count = 0
+                try:
+                    while limit == 0 or count < limit:
+                        line = data.next()
+                        count += 1
+                        yield ','.join(line) + '\n'
+                except StopIteration:
+                    pass
+
+        return stream

--- a/app/resonant-laboratory/server/__init__.py
+++ b/app/resonant-laboratory/server/__init__.py
@@ -2,7 +2,9 @@ import os
 from girder.api.rest import Resource
 from girder.constants import AssetstoreType
 from girder.utility.assetstore_utilities import setAssetstoreAdapter
-from SemanticFilesystemAssetstoreAdapter import SemanticFilesystemAssetstoreAdapter, SemanticGridFsAssetstoreAdapter
+from girder.utility.filesystem_assetstore_adapter import FilesystemAssetstoreAdapter
+from girder.utility.gridfs_assetstore_adapter import GridFsAssetstoreAdapter
+from semantic_assetstore_adapter import semantic_access
 from anonymousAccess import AnonymousAccess
 from versioning import Versioning
 
@@ -59,5 +61,5 @@ def load(info):
                                  versioning.versionNumber)
 
     # Install "semantic" download adapters into Girder's table of adapters.
-    setAssetstoreAdapter(AssetstoreType.FILESYSTEM, SemanticFilesystemAssetstoreAdapter)
-    setAssetstoreAdapter(AssetstoreType.GRIDFS, SemanticGridFsAssetstoreAdapter)
+    setAssetstoreAdapter(AssetstoreType.FILESYSTEM, semantic_access(FilesystemAssetstoreAdapter))
+    setAssetstoreAdapter(AssetstoreType.GRIDFS, semantic_access(GridFsAssetstoreAdapter))

--- a/app/resonant-laboratory/server/__init__.py
+++ b/app/resonant-laboratory/server/__init__.py
@@ -2,7 +2,7 @@ import os
 from girder.api.rest import Resource
 from girder.constants import AssetstoreType
 from girder.utility.assetstore_utilities import setAssetstoreAdapter
-from SemanticFilesystemAssetstoreAdapter import SemanticFilesystemAssetstoreAdapter
+from SemanticFilesystemAssetstoreAdapter import SemanticFilesystemAssetstoreAdapter, SemanticGridFsAssetstoreAdapter
 from anonymousAccess import AnonymousAccess
 from versioning import Versioning
 
@@ -58,5 +58,6 @@ def load(info):
     info['apiRoot'].system.route('GET', ('resonantLaboratoryVersion', ),
                                  versioning.versionNumber)
 
-    # Install "semantic" download adapter into Girder's table of adapters.
+    # Install "semantic" download adapters into Girder's table of adapters.
     setAssetstoreAdapter(AssetstoreType.FILESYSTEM, SemanticFilesystemAssetstoreAdapter)
+    setAssetstoreAdapter(AssetstoreType.GRIDFS, SemanticGridFsAssetstoreAdapter)

--- a/app/resonant-laboratory/server/__init__.py
+++ b/app/resonant-laboratory/server/__init__.py
@@ -1,5 +1,8 @@
 import os
 from girder.api.rest import Resource
+from girder.constants import AssetstoreType
+from girder.utility.assetstore_utilities import setAssetstoreAdapter
+from SemanticFilesystemAssetstoreAdapter import SemanticFilesystemAssetstoreAdapter
 from anonymousAccess import AnonymousAccess
 from versioning import Versioning
 
@@ -54,3 +57,6 @@ def load(info):
     versioning = Versioning()
     info['apiRoot'].system.route('GET', ('resonantLaboratoryVersion', ),
                                  versioning.versionNumber)
+
+    # Install "semantic" download adapter into Girder's table of adapters.
+    setAssetstoreAdapter(AssetstoreType.FILESYSTEM, SemanticFilesystemAssetstoreAdapter)

--- a/app/resonant-laboratory/server/semantic_assetstore_adapter.py
+++ b/app/resonant-laboratory/server/semantic_assetstore_adapter.py
@@ -3,8 +3,6 @@ import csv
 import json
 import sys
 from girder.models.model_base import GirderException
-from girder.utility.filesystem_assetstore_adapter import FilesystemAssetstoreAdapter
-from girder.utility.gridfs_assetstore_adapter import GridFsAssetstoreAdapter
 
 
 class StreamFile(object):
@@ -171,6 +169,3 @@ def semantic_access(Cls):
             return stream
 
     return NewCls
-
-SemanticFilesystemAssetstoreAdapter = semantic_access(FilesystemAssetstoreAdapter)
-SemanticGridFsAssetstoreAdapter = semantic_access(GridFsAssetstoreAdapter)

--- a/app/resonant-laboratory/server/test-stream-file.py
+++ b/app/resonant-laboratory/server/test-stream-file.py
@@ -10,6 +10,12 @@ def stream():
     yield ' what\'s up?\n'
     yield 'yay!!!'
 
+line_list = [
+    'hello goodbye adios\n',
+    'buenos dias what\'s up?\n',
+    'yay!!!'
+]
+
 
 class TestStreamFile(unittest.TestCase):
     def test_read(self):
@@ -38,11 +44,7 @@ class TestStreamFile(unittest.TestCase):
         sf = StreamFile(stream())
 
         lines = sf.readlines()
-        self.assertEqual(lines, [
-            'hello goodbye adios\n',
-            'buenos dias what\'s up?\n',
-            'yay!!!'
-        ])
+        self.assertEqual(lines, line_list)
 
     def test_overread(self):
         sf = StreamFile(stream())
@@ -53,6 +55,22 @@ class TestStreamFile(unittest.TestCase):
         text = sf.read(len(target) + 10)
 
         self.assertEqual(text, target)
+
+    def test_generator(self):
+        sf = StreamFile(stream())
+
+        self.assertEqual(sf.next(), 'hello goodbye adios\n')
+        self.assertEqual(sf.next(), 'buenos dias what\'s up?\n')
+        self.assertEqual(sf.next(), 'yay!!!')
+
+        self.assertRaises(StopIteration, sf.next)
+
+    def test_generator_list(self):
+        sf = StreamFile(stream())
+
+        lines = list(sf)
+
+        self.assertEqual(lines, line_list)
 
 if __name__ == '__main__':
     unittest.main()

--- a/app/resonant-laboratory/server/test-stream-file.py
+++ b/app/resonant-laboratory/server/test-stream-file.py
@@ -1,0 +1,58 @@
+import unittest
+from SemanticFilesystemAssetstoreAdapter import StreamFile
+
+
+def stream():
+    yield 'hello '
+    yield 'goodbye '
+    yield 'adios\n'
+    yield 'buenos dias'
+    yield ' what\'s up?\n'
+    yield 'yay!!!'
+
+
+class TestStreamFile(unittest.TestCase):
+    def test_read(self):
+        sf = StreamFile(stream())
+
+        word = sf.read(5)
+        self.assertEqual(word, 'hello')
+
+        self.assertFalse(sf.eof)
+
+        rest = sf.read()
+        self.assertEqual(rest, ' goodbye adios\nbuenos dias what\'s up?\nyay!!!')
+
+        self.assertTrue(sf.eof)
+
+        after = sf.read()
+        self.assertEqual(after, '')
+
+    def test_readline(self):
+        sf = StreamFile(stream())
+
+        line = sf.readline()
+        self.assertEqual(line, 'hello goodbye adios\n')
+
+    def test_readlines(self):
+        sf = StreamFile(stream())
+
+        lines = sf.readlines()
+        self.assertEqual(lines, [
+            'hello goodbye adios\n',
+            'buenos dias what\'s up?\n',
+            'yay!!!'
+        ])
+
+    def test_overread(self):
+        sf = StreamFile(stream())
+
+        target = stream()
+        target = ''.join(list(target))
+
+        text = sf.read(len(target) + 10)
+
+        self.assertEqual(text, target)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Note:** *I am not currently planning to actually merge this to master; it's here mainly to keep everyone in the loop and serve as a point of discussion.*

This PR engages Girder's new capability to install custom classes into its factory for assetstore adapters. The one implemented here falls back on the usual adapter in most cases, and exhibits new behavior if `extraParameters` is set.

Right now, as a matter of proof of concept, it accepts two parameters: `offset` and `limit`, and the target file/item must be a CSV file. The adapter extracts the header line and then `limit` data lines, beginning with the line numbered `offset`.

Generally speaking, that behavior will be replaced with more careful behavior that can understand Mongo-style database filter queries in addition to limit/offset, and also returns the data in a JSON-objects style (and of course this behavior can change to suit whatever is needed by Resonant Laboratory).

I have already discussed some code strategy with @alex-r-bigelow. He has two branches in-flight with a relatively large set of changes; once those are stable and merged together, my idea is that he can merge this branch into his, and from there we can work on the specific semantics we want in earnest.

I have also discussed with @jeffbaumes the idea that this adapter extension maybe ought to exist more as a decorator for existing classes, rather than a subclassing of a specific adapter class, so that its behavior can be used with both `FilesystemAssetstoreAdapter` and `GridFSAssetstoreAdapter`.