### PR TITLE
Implement handling of not-clauses in Mongo backend

### DIFF
--- a/app/resonant-laboratory/querylang/test/query.js
+++ b/app/resonant-laboratory/querylang/test/query.js
@@ -20,6 +20,18 @@ const disjunction_expression = [
   'age > 22 or age < 20'
 ];
 
+const not_expression = [
+  'not(age < 22 and age > 20)',
+  'not(age <= 22 and age > 20)',
+  'not(age > 22 and age < 20)',
+  'not(age >= 22 and age < 20)',
+  'not(age = 10)',
+  'not(age != 10)',
+  'not(age in [1, 2, 3, 4, 5])',
+  'not(age not in [1, 2, 3, 4, 5])',
+  'not(not(age > 22))'
+];
+
 function test_expressions (t, exprs, baseline_path) {
   const asts = exprs.map(parseToAst);
 
@@ -46,6 +58,11 @@ test('Conjunction expression parsing', t => {
 
 test('Disjunction expression parsing', t => {
   test_expressions(t, disjunction_expression, './app/resonant-laboratory/server/test/disjunction-ast-baselines.json');
+  t.end();
+});
+
+test('Not expression parsing', t => {
+  test_expressions(t, not_expression, './app/resonant-laboratory/server/test/not-ast-baselines.json');
   t.end();
 });
 

--- a/app/resonant-laboratory/server/querylang.py
+++ b/app/resonant-laboratory/server/querylang.py
@@ -60,20 +60,76 @@ _mongo_operators = {
 }
 
 
-def astToMongo(ast):
+def _astToMongo_helper(ast):
     """Convert a query language AST into an equivalent Mongo filter."""
     operator = ast['operator']
     operands = ast['operands']
 
     if operator in ['or', 'and']:
-        left = astToMongo(operands[0])
-        right = astToMongo(operands[1])
+        left = _astToMongo_helper(operands[0])
+        right = _astToMongo_helper(operands[1])
 
         return {_mongo_operators[operator]: [left, right]}
     elif operator == 'not':
-        raise RuntimeError()
+        raise TypeError('_astToMongo_helper() cannot operate on an AST with not-nodes.')
     elif operator in ['in', 'not in', '<=', '<', '>=', '>', '=', '!=']:
         field = operands[0]
         value = operands[1]
 
         return {field: {_mongo_operators[operator]: value}}
+
+
+def _invert(ast):
+    """Invert the polarity of a boolean expression."""
+    operator = ast['operator']
+    operands = ast['operands']
+
+    if operator == 'not':
+        # To invert a not expression, just remove the not.
+        return _eliminate_not(operands)
+    elif operator in ['and', 'or']:
+        # For and/or expressions, apply DeMorgan's laws.
+        new_operator = 'and' if operator == 'or' else 'or'
+        new_operands = map(lambda x: {'operator': 'not', 'operands': x}, operands)
+
+        return {'operator': new_operator,
+                'operands': map(_eliminate_not, new_operands)}
+    elif operator in ['in', 'not in']:
+        # For inclusion operators, just switch the one that was being used.
+        return {'operator': 'in' if operator == 'not in' else 'not in',
+                'operands': operands}
+    elif operator[0] in ['<', '>']:
+        # For comparison operators, flip the operator around.
+        new_operator = '<' if operator[0] == '>' else '>'
+        if len(operator) == 1:
+            new_operator += '='
+
+        return {'operator': new_operator,
+                'operands': operands}
+    else:
+        # For equality operators, just switch the operator
+        return {'operator': '=' if operator == '!=' else '!=',
+                'operands': operands}
+
+
+def _eliminate_not(ast):
+    """Eliminate all not-nodes in the AST by transforming their contents."""
+    operator = ast['operator']
+    operands = ast['operands']
+
+    if operator in ['and', 'or']:
+        # And/or expressions have two boolean operands that must be processed
+        # recursively.
+        return {'operator': operator,
+                'operands': map(_eliminate_not, operands)}
+    elif operator in ['in', 'not in', '<=', '<', '>=', '>', '=', '!=']:
+        # Operator expressions that work on constant values stay unchanged.
+        return ast
+    else:
+        # Not expressions lose the not itself and invert the operand.
+        return _eliminate_not(_invert(operands))
+
+
+def astToMongo(ast):
+    """Run the AST-to-mongo helper function above after converting it to a not-free equivalent AST."""
+    return _astToMongo_helper(_eliminate_not(ast))

--- a/app/resonant-laboratory/server/querylang.py
+++ b/app/resonant-laboratory/server/querylang.py
@@ -27,7 +27,7 @@ def astToFunction(ast):
 
         return lambda row: f0(row) and f1(row)
     elif operator == 'not':
-        f = astToFunction(operands[0])
+        f = astToFunction(operands)
         return lambda row: not f(row)
     elif operator == 'in':
         field = operands[0]

--- a/app/resonant-laboratory/server/test-querylang.py
+++ b/app/resonant-laboratory/server/test-querylang.py
@@ -64,6 +64,30 @@ class TestQueryLanguageMongo(unittest.TestCase):
         for expr, baseline in zip(map(ql.astToMongo, asts), baselines):
             self.assertEqual(expr, baseline)
 
+    def test_not_expressions(self):
+        """Test not expressions."""
+        asts = None
+        with open('test/not-ast-baselines.json') as f:
+            asts = json.load(f)
+
+        baselines = [
+            {'$or': [{'age': {'$gte': 22}},
+                     {'age': {'$lte': 20}}]},
+            {'$or': [{'age': {'$gt': 22}},
+                     {'age': {'$lte': 20}}]},
+            {'$or': [{'age': {'$lte': 22}},
+                     {'age': {'$gte': 20}}]},
+            {'$or': [{'age': {'$lt': 22}},
+                     {'age': {'$gte': 20}}]},
+            {'age': {'$ne': 10}},
+            {'age': {'$eq': 10}},
+            {'age': {'$nin': [1, 2, 3, 4, 5]}},
+            {'age': {'$in': [1, 2, 3, 4, 5]}},
+            {'age': {'$gt': 22}}
+        ]
+
+        for expr, baseline in zip(map(ql.astToMongo, asts), baselines):
+            self.assertEqual(expr, baseline)
 
 if __name__ == '__main__':
     unittest.main()

--- a/app/resonant-laboratory/server/test/not-ast-baselines.json
+++ b/app/resonant-laboratory/server/test/not-ast-baselines.json
@@ -1,0 +1,155 @@
+[
+    {
+        "operator": "not",
+        "operands": {
+            "operator": "and",
+            "operands": [
+                {
+                    "operator": "<",
+                    "operands": [
+                        "age",
+                        22
+                    ]
+                },
+                {
+                    "operator": ">",
+                    "operands": [
+                        "age",
+                        20
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "operator": "not",
+        "operands": {
+            "operator": "and",
+            "operands": [
+                {
+                    "operator": "<=",
+                    "operands": [
+                        "age",
+                        22
+                    ]
+                },
+                {
+                    "operator": ">",
+                    "operands": [
+                        "age",
+                        20
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "operator": "not",
+        "operands": {
+            "operator": "and",
+            "operands": [
+                {
+                    "operator": ">",
+                    "operands": [
+                        "age",
+                        22
+                    ]
+                },
+                {
+                    "operator": "<",
+                    "operands": [
+                        "age",
+                        20
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "operator": "not",
+        "operands": {
+            "operator": "and",
+            "operands": [
+                {
+                    "operator": ">=",
+                    "operands": [
+                        "age",
+                        22
+                    ]
+                },
+                {
+                    "operator": "<",
+                    "operands": [
+                        "age",
+                        20
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "operator": "not",
+        "operands": {
+            "operator": "=",
+            "operands": [
+                "age",
+                10
+            ]
+        }
+    },
+    {
+        "operator": "not",
+        "operands": {
+            "operator": "!=",
+            "operands": [
+                "age",
+                10
+            ]
+        }
+    },
+    {
+        "operator": "not",
+        "operands": {
+            "operator": "in",
+            "operands": [
+                "age",
+                [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                ]
+            ]
+        }
+    },
+    {
+        "operator": "not",
+        "operands": {
+            "operator": "not in",
+            "operands": [
+                "age",
+                [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                ]
+            ]
+        }
+    },
+    {
+        "operator": "not",
+        "operands": {
+            "operator": "not",
+            "operands": {
+                "operator": ">",
+                "operands": [
+                    "age",
+                    22
+                ]
+            }
+        }
+    }
+]


### PR DESCRIPTION
The `not` keyword was a problem for Mongo due to the way it works in Mongo queries. The solution in this PR is to make a pass over an AST to remove all instances of `not`-clauses. This is done by replacing the `not`-node with an appropriate node that implements the inverse semantics. For example, `not(and(age > 5, age < 7))` becomes `or(age <= 5, age >= 7)` (invoking DeMorgan's laws to make the transformation).

This also adds a bit of testing for `not`-expressions.