### PR TITLE
Make error dialog behavior consistent between OK button and close box (return to starting screen)

### DIFF
--- a/app/resonant-laboratory/views/layout/Overlay/index.js
+++ b/app/resonant-laboratory/views/layout/Overlay/index.js
@@ -100,6 +100,8 @@ let Overlay = Backbone.View.extend({
       message = errorObj.responseJSON.message;
     } else if (errorObj.message) {
       message = errorObj.message;
+    } else if (typeof errorObj === 'string') {
+      message = errorObj;
     } else {
       // Fallback if I can't tell what it is
       message = 'Unknown error; maybe the console contains some clues';
@@ -146,7 +148,7 @@ let Overlay = Backbone.View.extend({
   renderReallyBadErrorScreen: function (message, details) {
     this.render(this.getScreen(reallyBadErrorTemplate, message, details), false,
       () => {
-        this.$el.find('#okButton').on('click', () => {
+        this.$el.find('#okButton, #closeOverlay').on('click', () => {
           window.mainPage.switchProject(null)
             .then(() => {
               window.mainPage.overlay.render('StartingScreen');


### PR DESCRIPTION
Fix #300

Also display string errors in the error dialog box