### PR TITLE
Fix inferAll to allow fields with embedded periods

### DIFF
--- a/src/candela/components/LineUp/index.js
+++ b/src/candela/components/LineUp/index.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import datalib from 'datalib';
 import d3 from 'd3';
 import VisComponent from '../../VisComponent';
+import { inferAll } from '../../util';
 import LineUpJS from 'LineUpJS/src/main.js';
 import 'LineUpJS/dist/style.css';
 import './index.styl';
@@ -258,7 +259,7 @@ export default class LineUp extends VisComponent {
       label: 'Combined',
       children: []
     };
-    let attributes = datalib.type.all(data);
+    let attributes = inferAll(data);
     /* If fields was specified, use them in order (if they exist as data
      * attributes).  If fields was not specified, use the data attributes. */
     let fields = this.options.fields ? this.options.fields : Object.keys(attributes);

--- a/src/candela/components/OnSet/index.js
+++ b/src/candela/components/OnSet/index.js
@@ -1,5 +1,5 @@
 import d3 from 'd3';
-import dl from 'datalib';
+import { unique } from 'datalib';
 import onset from 'onset';
 import VisComponent from '../../VisComponent';
 
@@ -79,7 +79,7 @@ export default class OnSet extends VisComponent {
     // A set is defined by records sharing a field value.
     if (this.options.fields) {
       this.options.fields.forEach(field => {
-        let distinct = dl.unique(this.options.data, d => d[field]);
+        let distinct = unique(this.options.data, d => d[field]);
         this.options.data.forEach((d, i) => {
           distinct.forEach(v => {
             if (v === d[field]) {

--- a/src/candela/components/UpSet/index.js
+++ b/src/candela/components/UpSet/index.js
@@ -1,6 +1,7 @@
 import d3 from 'd3';
-import dl from 'datalib';
+import { unique } from 'datalib';
 import VisComponent from '../../VisComponent';
+import { inferAll } from '../../util';
 import * as upset from 'UpSet';
 import template from './template.html';
 
@@ -100,7 +101,7 @@ export default class UpSet extends VisComponent {
     // A set is defined by records sharing a field value.
     if (this.options.fields) {
       this.options.fields.forEach(field => {
-        let distinct = dl.unique(this.options.data, d => d[field]);
+        let distinct = unique(this.options.data, d => d[field]);
         distinct.forEach(v => header.push(field + ' ' + v));
         this.options.data.forEach((d, i) => {
           distinct.forEach(v => {
@@ -123,7 +124,7 @@ export default class UpSet extends VisComponent {
     // Add metadata fields.
     if (this.options.metadata) {
       if (!this.options.data.__types__) {
-        dl.read(this.options.data, {parse: 'auto'});
+        this.options.data.__types__ = inferAll(this.options.data);
       }
       const upsetTypeMap = {
         string: 'string',

--- a/src/candela/util/index.js
+++ b/src/candela/util/index.js
@@ -1,3 +1,5 @@
+import { keys, type } from 'datalib';
+
 export function getElementSize (el) {
   const style = window.getComputedStyle(el, null);
   const width = window.parseInt(style.getPropertyValue('width'));
@@ -30,4 +32,13 @@ export function minmax (data) {
   }
 
   return range;
+}
+
+export function inferAll (data) {
+  let fields = keys(data[0]);
+  let types = {};
+  for (let i = 0; i < fields.length; i += 1) {
+    types[fields[i]] = type.infer(data, '[' + fields[i] + ']');
+  }
+  return types;
 }

--- a/src/candela/util/test/util.js
+++ b/src/candela/util/test/util.js
@@ -1,0 +1,9 @@
+import test from 'tape-catch';
+import { inferAll } from '..';
+
+test('inferAll()', t => {
+  t.deepEqual(inferAll([{'a.b': 1}]), {'a.b': 'integer'}, 'should work on fields with nested dots');
+  t.deepEqual(inferAll([{'a': {'b': 1}}]), {'a': 'string'}, 'should only accept top-level fields');
+
+  t.end();
+});

--- a/src/candela/util/test/util.js
+++ b/src/candela/util/test/util.js
@@ -1,9 +1,14 @@
 import test from 'tape-catch';
 import { inferAll } from '..';
+import { read } from 'datalib';
 
 test('inferAll()', t => {
   t.deepEqual(inferAll([{'a.b': 1}]), {'a.b': 'integer'}, 'should work on fields with nested dots');
   t.deepEqual(inferAll([{'a': {'b': 1}}]), {'a': 'string'}, 'should only accept top-level fields');
+
+  let testData = [{a: 1, b: 'foo', c: 1.5}];
+  read(testData, {parse: 'auto'});
+  t.deepEqual(testData.__types__, inferAll(testData), 'should work identically to datalib read() when no nested dots');
 
   t.end();
 });

--- a/src/candela/util/vega/index.js
+++ b/src/candela/util/vega/index.js
@@ -1,8 +1,8 @@
 import d3 from 'd3';
 import vg from 'vega';
-import dl from 'datalib';
+import { isArray, isString } from 'datalib';
 import axisTemplate from './axis.json';
-import { getElementSize } from '..';
+import { getElementSize, inferAll } from '..';
 
 let getNestedRec = function (spec, parts) {
   if (spec === undefined || parts.length === 0) {
@@ -119,7 +119,7 @@ let templateFunctions = {
 
   length: function (args, options, scope) {
     let a = transform(args[0], options, scope);
-    if (dl.isArray(a) || dl.isString(a)) {
+    if (isArray(a) || isString(a)) {
       return a.length;
     }
     return 0;
@@ -214,7 +214,7 @@ let templateFunctions = {
     let opt = transform(args[0], options, scope);
     if (opt.data && Array.isArray(opt.data) && opt.field) {
       if (!opt.data.__types__) {
-        dl.read(opt.data, {parse: 'auto'});
+        opt.data.__types__ = inferAll(opt.data);
       }
       let type = opt.data.__types__[opt.field];
       if (type === 'string') {


### PR DESCRIPTION
`datalib.type.all` and `datalib.read` were failing when datasets had field names with embedded periods. This implements and tests a new utility function `inferAll` which calls `datalib.infer` in a way that ensures periods won't be split.