### PR TITLE
Use inspect module to determine plugin base directory

### DIFF
--- a/app/resonant-laboratory/server/datasetItem.py
+++ b/app/resonant-laboratory/server/datasetItem.py
@@ -27,6 +27,12 @@ from girder.plugins.database_assetstore.assetstore import getDbInfoForFile
 
 TRUE_VALUES = set([True, 'true', 1, 'True'])
 
+def pluginDir():
+    me = inspect.stack()[0][1]
+    mydir = os.path.dirname(me)
+    pluginDir = os.path.join(mydir, '..')
+
+    return os.path.abspath(pluginDir)
 
 class DatasetItem(Resource):
     def __init__(self, app):
@@ -34,8 +40,7 @@ class DatasetItem(Resource):
         self.app = app
 
         # Load up the external foreign code snippets
-        codePath = subprocess.check_output(['girder-install', 'plugin-path']).strip()
-        codePath = os.path.join(codePath, 'resonant-laboratory/general_purpose')
+        codePath = os.path.join(pluginDir(), 'general_purpose')
 
         self.foreignCode = {}
 

--- a/app/resonant-laboratory/server/datasetItem.py
+++ b/app/resonant-laboratory/server/datasetItem.py
@@ -16,6 +16,7 @@ import cherrypy
 from pymongo import MongoClient
 from anonymousAccess import loadAnonymousItem
 from querylang import astToMongo
+from pluginDir import pluginDir
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException, loadmodel
@@ -26,13 +27,6 @@ from girder.plugins.database_assetstore.assetstore import getDbInfoForFile
 
 
 TRUE_VALUES = set([True, 'true', 1, 'True'])
-
-def pluginDir():
-    me = inspect.stack()[0][1]
-    mydir = os.path.dirname(me)
-    pluginDir = os.path.join(mydir, '..')
-
-    return os.path.abspath(pluginDir)
 
 class DatasetItem(Resource):
     def __init__(self, app):

--- a/app/resonant-laboratory/server/pluginDir.py
+++ b/app/resonant-laboratory/server/pluginDir.py
@@ -3,6 +3,12 @@ import os
 
 
 def pluginDir():
+    # This function works by grabbing the current stack, examining the first
+    # frame (which refers to the invocation of this very function), and
+    # extracting the second element of it, which refers to the filename
+    # containing the module that exports this function. Since that module is in
+    # the 'server' subdirectory of the top-level directory, appending .. to that
+    # path gets us the base plugin directory.
     me = inspect.stack()[0][1]
     mydir = os.path.dirname(me)
     pluginDir = os.path.join(mydir, '..')

--- a/app/resonant-laboratory/server/pluginDir.py
+++ b/app/resonant-laboratory/server/pluginDir.py
@@ -1,0 +1,10 @@
+import inspect
+import os
+
+
+def pluginDir():
+    me = inspect.stack()[0][1]
+    mydir = os.path.dirname(me)
+    pluginDir = os.path.join(mydir, '..')
+
+    return os.path.abspath(pluginDir)

--- a/app/resonant-laboratory/server/versioning.py
+++ b/app/resonant-laboratory/server/versioning.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from pluginDir import pluginDir
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, RestException, loadmodel
@@ -19,9 +20,7 @@ class Versioning(Resource):
         try:
             # Try to figure out what git branch we're on... TODO: if this fails
             # for whatever reason, return the actual version number instead
-            currentPath = subprocess.check_output(['girder-install', 'plugin-path']).strip()
-            cwd = os.path.join(currentPath, 'resonant-laboratory')
-            statusText = subprocess.check_output(['git', 'status'], cwd=cwd)
+            statusText = subprocess.check_output(['git', 'status'], cwd=pluginDir())
             branch = statusText.split('\n')[0].replace('On branch ', '')
             if branch == 'master' or branch == 'release' or branch == '':
                 return 'master'


### PR DESCRIPTION
This PR replaces a brittle mechanism (using the `subprocess` module to ask `girder-install` what the Girder plugin path is) with a more robust one that uses the `inspect` module's reflection capabilities to figure out where the calling module, and therefore the `resonant-laboratory` directory, is.