### PR TITLE
Install bin bounds for ordinal bins

### DIFF
--- a/app/resonant-laboratory/general_purpose/histogram_reduce.js
+++ b/app/resonant-laboratory/general_purpose/histogram_reduce.js
@@ -49,6 +49,8 @@ if (binSettings.ordinalBins) {
     binLookup[bin.label] = histogram.length;
     histogram.push({
       label: bin.label,
+      lowBound: bin.lowBound,
+      highBound: bin.highBound,
       count: 0
     });
   });


### PR DESCRIPTION
Without `lowBound` and `highBound` properties on the returned bins, the client will think these are categorical bins.