### PR TITLE
Remove faulty caching mechanism for updated data requests

### DIFF
--- a/app/resonant-laboratory/models/Project.js
+++ b/app/resonant-laboratory/models/Project.js
@@ -398,10 +398,6 @@ let Project = MetadataItem.extend({
     return Object.assign({}, this.getAssignedVisFields(index), visDetails.options || {});
   },
   shapeDataForVis: function (index = 0) {
-    if (index in this.cache.visDatasetPromises) {
-      return this.cache.visDatasetPromises[index];
-    }
-
     let meta = this.getMeta();
     if (meta.datasets.length <= index) {
       // The indicated dataset isn't loaded yet...


### PR DESCRIPTION
After filters are changed, the histograms and data panel view of the new data update properly, but the visualization never receives the update, instead relying on a out-of-date, cached promise containing data from the first download thereof.

This simply removes the caching mechanism, allowing the visualization to update properly.

@alex-r-bigelow, I am not sure what the error in logic was; maybe you can diagnose that.

@jeffbaumes if you test and approve this, I can push the fix up to our deployment instance.