### PR TITLE
Fix status caching issue when reassigning project

### DIFF
--- a/app/resonant-laboratory/models/UserPreferences.js
+++ b/app/resonant-laboratory/models/UserPreferences.js
@@ -75,10 +75,11 @@ you move or delete this item, your preferences will be lost.`,
     // made), display a notification about where the project was moved.
     // Because we're now working on a copy, we should also fire the project
     // creation event
+    window.mainPage.project.updateStatus();
     window.mainPage.project.cache.status.then(status => {
       let notification = 'You are now working on a copy of this project in ';
       if (status.visibility === 'PublicScratch') {
-        notification = 'the public scratch space. Log in to take ownership of this project.';
+        notification += 'the public scratch space. Log in to take ownership of this project.';
       } else if (status.visibility === 'PrivateUser') {
         notification += 'your Private folder.';
       } else {


### PR DESCRIPTION
Fixes #411.

The cached status was not updating, meaning a non-logged-in user would get an error window when viewing someone else's project. Explicitly updating the cache fixes this issue.

Also fixes a string append issue for the message that appears.

To see the issue resolved, copy a created project link (ensure data and project are public) to a non-logged in session. It used to throw an error but now correctly creates an anonymous copy and has an appropriate status message.