### PR TITLE
Fix date handling by using read() instead of inferAll() in axis logic

### DIFF
--- a/src/candela/components/UpSet/index.js
+++ b/src/candela/components/UpSet/index.js
@@ -1,7 +1,7 @@
 import d3 from 'd3';
 import { unique } from 'datalib';
 import VisComponent from '../../VisComponent';
-import { inferAll } from '../../util';
+import { read } from '../../util';
 import * as upset from 'UpSet';
 import template from './template.html';
 
@@ -124,7 +124,7 @@ export default class UpSet extends VisComponent {
     // Add metadata fields.
     if (this.options.metadata) {
       if (!this.options.data.__types__) {
-        this.options.data.__types__ = inferAll(this.options.data);
+        read(this.options.data);
       }
       const upsetTypeMap = {
         string: 'string',

--- a/src/candela/util/index.js
+++ b/src/candela/util/index.js
@@ -1,4 +1,4 @@
-import { keys, type } from 'datalib';
+import { keys, type, read as dlread } from 'datalib';
 
 export function getElementSize (el) {
   const style = window.getComputedStyle(el, null);
@@ -34,6 +34,8 @@ export function minmax (data) {
   return range;
 }
 
+// Version of datalib.type.inferAll() that handles fields
+// with nested periods
 export function inferAll (data) {
   let fields = keys(data[0]);
   let types = {};
@@ -41,4 +43,11 @@ export function inferAll (data) {
     types[fields[i]] = type.infer(data, '[' + fields[i] + ']');
   }
   return types;
+}
+
+// Version of datalib.read() that uses our inferAll() to handle
+// fields with nested periods
+export function read (data) {
+  data.__types__ = inferAll(data);
+  dlread(data, {parse: data.__types__});
 }

--- a/src/candela/util/test/util.js
+++ b/src/candela/util/test/util.js
@@ -1,14 +1,27 @@
 import test from 'tape-catch';
-import { inferAll } from '..';
-import { read } from 'datalib';
+import { inferAll, read } from '..';
+import dl from 'datalib';
 
 test('inferAll()', t => {
   t.deepEqual(inferAll([{'a.b': 1}]), {'a.b': 'integer'}, 'should work on fields with nested dots');
   t.deepEqual(inferAll([{'a': {'b': 1}}]), {'a': 'string'}, 'should only accept top-level fields');
 
   let testData = [{a: 1, b: 'foo', c: 1.5}];
-  read(testData, {parse: 'auto'});
-  t.deepEqual(testData.__types__, inferAll(testData), 'should work identically to datalib read() when no nested dots');
+  t.deepEqual(dl.type.inferAll(testData), inferAll(testData), 'should work identically to datalib inferAll() when no nested dots');
+
+  t.end();
+});
+
+test('read()', t => {
+  let testData = [{'a.b': 1}];
+  read(testData);
+  t.deepEqual({'a.b': 'integer'}, testData.__types__, 'should work on fields with nested dots');
+
+  let testData1 = [{a: 1, b: 'foo', c: 1.5}];
+  let testData2 = [{a: 1, b: 'foo', c: 1.5}];
+  dl.read(testData1, {parse: 'auto'});
+  read(testData2);
+  t.deepEqual(testData1.__types__, testData2.__types__, 'should work identically to datalib read() when no nested dots');
 
   t.end();
 });

--- a/src/candela/util/vega/index.js
+++ b/src/candela/util/vega/index.js
@@ -2,7 +2,7 @@ import d3 from 'd3';
 import vg from 'vega';
 import { isArray, isString } from 'datalib';
 import axisTemplate from './axis.json';
-import { getElementSize, inferAll, read } from '..';
+import { getElementSize, read } from '..';
 
 let getNestedRec = function (spec, parts) {
   if (spec === undefined || parts.length === 0) {

--- a/src/candela/util/vega/index.js
+++ b/src/candela/util/vega/index.js
@@ -2,7 +2,7 @@ import d3 from 'd3';
 import vg from 'vega';
 import { isArray, isString } from 'datalib';
 import axisTemplate from './axis.json';
-import { getElementSize, inferAll } from '..';
+import { getElementSize, inferAll, read } from '..';
 
 let getNestedRec = function (spec, parts) {
   if (spec === undefined || parts.length === 0) {
@@ -214,7 +214,7 @@ let templateFunctions = {
     let opt = transform(args[0], options, scope);
     if (opt.data && Array.isArray(opt.data) && opt.field) {
       if (!opt.data.__types__) {
-        opt.data.__types__ = inferAll(opt.data);
+        read(opt.data);
       }
       let type = opt.data.__types__[opt.field];
       if (type === 'string') {


### PR DESCRIPTION
Fixes #409.

It turns out that not handling dates was a bug introduced by #380. We needed to be more careful about keeping the logic of datalib's `read()` instead of using `inferAll()` (see change in src/candela/util/vega/index.js). `read()` does the proper conversions of dates (including Date() objects) into the normalized millisecond format for use by Vega scales/axes.

This branch adds testing that more directly compares our tweaked versions of `inferAll()` and `read()`, making them function identically to the datalib versions except in the case of having periods in the field names, which our versions handle.

If my PR to datalib (or something like it) is accepted and released, we will not need our own versions of `inferAll` and `read`. See https://github.com/vega/datalib/pull/80.