### PR TITLE
Update onset to prevent CSS leakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "dependencies": {
     "LineUpJS": "git+https://github.com/Caleydo/lineup.js#0cd7f3f2ad06c498c09612daf5f3e2a36c07536d",
     "UpSet": "git+https://github.com/VCG/upset#6e8b7a172443dd6b4f4324d1a3368287e9e9c089",
-    "onset": "git+https://github.com/Kitware/setvis#238c57a0bc2d37feb898d7ec630f481529bd528b",
+    "onset": "git+https://github.com/Kitware/setvis#506bfccff63b0c8f5c39a81d299ed310e5e8fbff",
     "brace": "^0.7.0",
     "d3": "^3.5.14",
     "datalib": "^1.6.3",


### PR DESCRIPTION
Fixes #402 

normalize.css was being pulled in through OnSet, which does funny things to global elements when included after other CSS, such as adding padding around `ul` tags. This was resolved in https://github.com/Kitware/setvis/pull/3, and this PR updated OnSet to the new version.

There is still special CSS logic in the sphinx docs to deal with this, which we need to keep until this version of Candela is on CDN - another reason to move forward with semantic-release / commitizen.