### PR TITLE
Remove ES6 example code and validate JS code examples

### DIFF
--- a/docs/components/barchart.rst
+++ b/docs/components/barchart.rst
@@ -12,12 +12,12 @@ Example
 
     <div id="barchart-example"></div>
     <script type="text/javascript" >
-        var el = document.getElementById('barchart-example'), data = [];
-        for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
-        var vis = new candela.components.BarChart(el, {
-            data: data, x: 'a', y: 'b',
-            width: 700, height: 400});
-        vis.render();
+      var el = document.getElementById('barchart-example'), data = [];
+      for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
+      var vis = new candela.components.BarChart(el, {
+        data: data, x: 'a', y: 'b',
+        width: 700, height: 400});
+      vis.render();
     </script>
 
 **JavaScript**
@@ -27,14 +27,23 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
+      var data = [];
+      for (var d = 0; d < 10; d += 1) {
+        data.push({
+          a: d,
+          b: d
+        });
+      }
 
-    var vis = new candela.components.BarChart(el, {data: data, x: 'a', y: 'b'});
-    vis.render();
+      var vis = new candela.components.BarChart(el, {
+        data: data,
+        x: 'a',
+        y: 'b'
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/barchart.rst
+++ b/docs/components/barchart.rst
@@ -20,25 +20,13 @@ Example
         vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import BarChart from candela.components.BarChart
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
-
-    let vis = new BarChart(el, {data: data, x: 'a', y: 'b'});
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
@@ -47,6 +35,8 @@ Example
 
     var vis = new candela.components.BarChart(el, {data: data, x: 'a', y: 'b'});
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/barchart.rst
+++ b/docs/components/barchart.rst
@@ -25,7 +25,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/boxplot.rst
+++ b/docs/components/boxplot.rst
@@ -29,14 +29,22 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d/2 + 7});
+      var data = [];
+      for (var d = 0; d < 10; d += 1) {
+        data.push({
+          a: d,
+          b: d/2 + 7
+        });
+      }
 
-    var vis = new candela.components.BoxPlot(el, {data: data, fields: ['a', 'b']});
-    vis.render();
+      var vis = new candela.components.BoxPlot(el, {
+        data: data,
+        fields: ['a', 'b']
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/boxplot.rst
+++ b/docs/components/boxplot.rst
@@ -15,40 +15,30 @@ Example
     <div id="boxplot-example"></div>
     <script type="text/javascript" >
         var el = document.getElementById('boxplot-example'), data = [];
-        for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
+        for (var d = 0; d < 10; d += 1) data.push({a: d, b: d/2 + 7});
         var vis = new candela.components.BoxPlot(el, {
             data: data, fields: ['a', 'b'],
             width: 700, height: 400});
         vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import BoxPlot from candela.components.BoxPlot
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
-
-    let vis = new BoxPlot(el, {data: data, fields: ['a', 'b']});
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
     var data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
+    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d/2 + 7});
 
     var vis = new candela.components.BoxPlot(el, {data: data, fields: ['a', 'b']});
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/boxplot.rst
+++ b/docs/components/boxplot.rst
@@ -27,7 +27,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/boxplot.rst
+++ b/docs/components/boxplot.rst
@@ -46,7 +46,7 @@ Example
 
     import candela
 
-    data = [{'a': d, 'b': d} for d in range(10)]
+    data = [{'a': d, 'b': d/2 + 7} for d in range(10)]
 
     candela.components.BoxPlot(data=data, fields=['a', 'b'])
 

--- a/docs/components/bulletchart.rst
+++ b/docs/components/bulletchart.rst
@@ -37,22 +37,22 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var vis = new candela.components.BulletChart(el, {
-      value: 0.8,
-      title: 'My measurement',
-      subtitle: '... it is really important',
-      ranges: [
-        { min: 0, max: 0.2, foreground: 'gray', background: 'red' },
-        { min: 0.2, max: 0.7, foreground: 'gray', background: 'yellow' },
-        { min: 0.7, max: 1, foreground: 'gray', background: 'green' }
-      ],
-      width: 700,
-      height: 100
-    });
-    vis.render();
+      var vis = new candela.components.BulletChart(el, {
+        value: 0.8,
+        title: 'My measurement',
+        subtitle: '... it is really important',
+        ranges: [
+          { min: 0, max: 0.2, foreground: 'gray', background: 'red' },
+          { min: 0.2, max: 0.7, foreground: 'gray', background: 'yellow' },
+          { min: 0.7, max: 1, foreground: 'gray', background: 'green' }
+        ],
+        width: 700,
+        height: 100
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/bulletchart.rst
+++ b/docs/components/bulletchart.rst
@@ -30,35 +30,12 @@ Example
       vis.render();
     </script>
 
-**ES6/Webpack**
-
-.. code-block:: js
-
-    import BulletChart from candela.components.BulletChart
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let vis = new BulletChart(el, {
-      value: 0.8,
-      title: 'My measurement',
-      subtitle: '... it is really important',
-      ranges: [
-        { min: 0, max: 0.2, foreground: 'gray', background: 'red' },
-        { min: 0.2, max: 0.7, foreground: 'gray', background: 'yellow' },
-        { min: 0.7, max: 1, foreground: 'gray', background: 'green' }
-      ],
-      width: 700,
-      height: 100
-    });
-    vis.render();
-
 **JavaScript**
 
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/bulletchart.rst
+++ b/docs/components/bulletchart.rst
@@ -53,10 +53,13 @@ Example
     });
     vis.render();
 
-**ES5**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
@@ -73,6 +76,8 @@ Example
       height: 100
     });
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/ganttchart.rst
+++ b/docs/components/ganttchart.rst
@@ -37,23 +37,23 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var data = [
-      {name: 'Do this', level: 1, start: 0, end: 5},
-      {name: 'This part 1', level: 2, start: 0, end: 3},
-      {name: 'This part 2', level: 2, start: 3, end: 5},
-      {name: 'Then that', level: 1, start: 5, end: 15},
-      {name: 'That part 1', level: 2, start: 5, end: 10},
-      {name: 'That part 2', level: 2, start: 10, end: 15}
-    ];
-    var vis = new candela.components.GanttChart(el, {
-      data: data, label: 'name',
-      start: 'start', end: 'end', level: 'level',
-      width: 700, height: 200
-    });
-    vis.render();
+      var data = [
+        {name: 'Do this', level: 1, start: 0, end: 5},
+        {name: 'This part 1', level: 2, start: 0, end: 3},
+        {name: 'This part 2', level: 2, start: 3, end: 5},
+        {name: 'Then that', level: 1, start: 5, end: 15},
+        {name: 'That part 1', level: 2, start: 5, end: 10},
+        {name: 'That part 2', level: 2, start: 10, end: 15}
+      ];
+      var vis = new candela.components.GanttChart(el, {
+        data: data, label: 'name',
+        start: 'start', end: 'end', level: 'level',
+        width: 700, height: 200
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/ganttchart.rst
+++ b/docs/components/ganttchart.rst
@@ -30,34 +30,13 @@ Example
       vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import GanttChart from candela.components.GanttChart
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [
-      {name: 'Do this', level: 1, start: 0, end: 5},
-      {name: 'This part 1', level: 2, start: 0, end: 3},
-      {name: 'This part 2', level: 2, start: 3, end: 5},
-      {name: 'Then that', level: 1, start: 5, end: 15},
-      {name: 'That part 1', level: 2, start: 5, end: 10},
-      {name: 'That part 2', level: 2, start: 10, end: 15}
-    ];
-    let vis = new GanttChart(el, {
-      data: data, label: 'name',
-      start: 'start', end: 'end', level: 'level',
-      width: 700, height: 200
-    });
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
@@ -75,6 +54,8 @@ Example
       width: 700, height: 200
     });
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/ganttchart.rst
+++ b/docs/components/ganttchart.rst
@@ -35,7 +35,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/geo.rst
+++ b/docs/components/geo.rst
@@ -42,49 +42,16 @@ Example
         vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import Geo from candela.components.Geo
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [
-      {lat: 41.702, lng: -87.644},
-      {lat: 41.617, lng: -87.693},
-      {lat: 41.715, lng: -87.712}
-    ];
-    let vis = new Geo(el, {
-      map: {
-        zoom: 10,
-        center: { x: -87.6194, y: 41.867516 }
-      },
-      layers: [
-        {
-          type: 'osm'
-        },
-        {
-          type: 'feature',
-          features: [
-            {
-              type: 'point',
-              data: data,
-              x: 'lng',
-              y: 'lat'
-            }
-          ]
-        }
-      ]
-    });
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
+    el.style.width = '500px';
+    el.style.height = '500px';
     document.body.appendChild(el);
 
     var data = [
@@ -115,6 +82,8 @@ Example
       ]
     });
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/geo.rst
+++ b/docs/components/geo.rst
@@ -49,39 +49,42 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    el.style.width = '500px';
-    el.style.height = '500px';
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      el.style.width = '500px';
+      el.style.height = '500px';
+      document.body.appendChild(el);
 
-    var data = [
-      {lat: 41.702, lng: -87.644},
-      {lat: 41.617, lng: -87.693},
-      {lat: 41.715, lng: -87.712}
-    ];
-    var vis = new candela.components.Geo(el, {
-      map: {
-        zoom: 10,
-        center: { x: -87.6194, y: 41.867516 }
-      },
-      layers: [
-        {
-          type: 'osm'
+      var data = [
+        {lat: 41.702, lng: -87.644},
+        {lat: 41.617, lng: -87.693},
+        {lat: 41.715, lng: -87.712}
+      ];
+      var vis = new candela.components.Geo(el, {
+        map: {
+          zoom: 10,
+          center: {
+            x: -87.6194,
+            y: 41.867516
+          }
         },
-        {
-          type: 'feature',
-          features: [
-            {
-              type: 'point',
-              data: data,
-              x: 'lng',
-              y: 'lat'
-            }
-          ]
-        }
-      ]
-    });
-    vis.render();
+        layers: [
+          {
+            type: 'osm'
+          },
+          {
+            type: 'feature',
+            features: [
+              {
+                type: 'point',
+                data: data,
+                x: 'lng',
+                y: 'lat'
+              }
+            ]
+          }
+        ]
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/geo.rst
+++ b/docs/components/geo.rst
@@ -47,7 +47,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     el.style.width = '500px';

--- a/docs/components/geodots.rst
+++ b/docs/components/geodots.rst
@@ -38,7 +38,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     el.style.width = '500px';

--- a/docs/components/geodots.rst
+++ b/docs/components/geodots.rst
@@ -33,36 +33,16 @@ Example
         vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import GeoDots from candela.components.GeoDots
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [
-      {lat: 41.702, lng: -87.644, a: 5},
-      {lat: 41.617, lng: -87.693, a: 15},
-      {lat: 41.715, lng: -87.712, a: 25}
-    ];
-    let vis = new GeoDots(el, {
-      zoom: 10,
-      center: { longitude: -87.6194, latitude: 41.867516 },
-      data: data,
-      latitude: 'lat',
-      longitude: 'lng',
-      size: 'a',
-      color: 'a'
-    });
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
+    el.style.width = '500px';
+    el.style.height = '500px';
     document.body.appendChild(el);
 
     var data = [
@@ -80,6 +60,8 @@ Example
       color: 'a'
     });
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/geodots.rst
+++ b/docs/components/geodots.rst
@@ -40,26 +40,29 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    el.style.width = '500px';
-    el.style.height = '500px';
-    document.body.appendChild(el);
+     var el = document.createElement('div')
+     el.style.width = '500px';
+     el.style.height = '500px';
+     document.body.appendChild(el);
 
-    var data = [
-      {lat: 41.702, lng: -87.644, a: 5},
-      {lat: 41.617, lng: -87.693, a: 15},
-      {lat: 41.715, lng: -87.712, a: 25}
-    ];
-    var vis = new candela.components.GeoDots(el, {
-      zoom: 10,
-      center: { longitude: -87.6194, latitude: 41.867516 },
-      data: data,
-      latitude: 'lat',
-      longitude: 'lng',
-      size: 'a',
-      color: 'a'
-    });
-    vis.render();
+     var data = [
+       {lat: 41.702, lng: -87.644, a: 5},
+       {lat: 41.617, lng: -87.693, a: 15},
+       {lat: 41.715, lng: -87.712, a: 25}
+     ];
+     var vis = new candela.components.GeoDots(el, {
+       zoom: 10,
+       center: {
+         longitude: -87.6194,
+         latitude: 41.867516
+       },
+       data: data,
+       latitude: 'lat',
+       longitude: 'lng',
+       size: 'a',
+       color: 'a'
+     });
+     vis.render();
     </script>
     </body>
 

--- a/docs/components/heatmap.rst
+++ b/docs/components/heatmap.rst
@@ -30,7 +30,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/heatmap.rst
+++ b/docs/components/heatmap.rst
@@ -32,16 +32,26 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: 10 - d, name: d});
+      var data = [];
+      for (var d = 0; d < 10; d += 1) {
+        data.push({
+          a: d,
+          b: 10 - d,
+          name: d
+        });
+      }
 
-    var vis = new candela.components.Heatmap(el, {
-      data: data, fields: ['a', 'b'], id: 'name',
-      width: 700, height: 400});
-    vis.render();
+      var vis = new candela.components.Heatmap(el, {
+        data: data,
+        fields: ['a', 'b'],
+        id: 'name',
+        width: 700,
+        height: 400
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/heatmap.rst
+++ b/docs/components/heatmap.rst
@@ -25,27 +25,13 @@ Example
         vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import Heatmap from candela.components.Heatmap
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: 10 - d, name: d});
-
-    let vis = new Heatmap(el, {
-      data: data, fields: ['a', 'b'], id: 'name',
-      width: 700, height: 400});
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
@@ -56,6 +42,8 @@ Example
       data: data, fields: ['a', 'b'], id: 'name',
       width: 700, height: 400});
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/histogram.rst
+++ b/docs/components/histogram.rst
@@ -27,29 +27,13 @@ Example
         vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import Histogram from candela.components.Histogram
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [];
-    for (var d = 0; d < 1000; d += 1) {
-      data.push({a: Math.sqrt(-2*Math.log(Math.random()))*Math.cos(2*Math.PI*Math.random())});
-    }
-
-    let vis = new Histogram(el, {
-      data: data, bin: 'a',
-      width: 700, height: 400});
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
@@ -62,6 +46,8 @@ Example
       data: data, bin: 'a',
       width: 700, height: 400});
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/histogram.rst
+++ b/docs/components/histogram.rst
@@ -34,18 +34,23 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var data = [];
-    for (var d = 0; d < 1000; d += 1) {
-      data.push({a: Math.sqrt(-2*Math.log(Math.random()))*Math.cos(2*Math.PI*Math.random())});
-    }
+      var data = [];
+      for (var d = 0; d < 1000; d += 1) {
+        data.push({
+          a: Math.sqrt(-2*Math.log(Math.random()))*Math.cos(2*Math.PI*Math.random())
+        });
+      }
 
-    var vis = new candela.components.Histogram(el, {
-      data: data, bin: 'a',
-      width: 700, height: 400});
-    vis.render();
+      var vis = new candela.components.Histogram(el, {
+        data: data,
+        bin: 'a',
+        width: 700,
+        height: 400
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/histogram.rst
+++ b/docs/components/histogram.rst
@@ -32,7 +32,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/linechart.rst
+++ b/docs/components/linechart.rst
@@ -30,17 +30,25 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
+      var data = [];
+      for (var d = 0; d < 10; d += 1) {
+        data.push({
+          a: d,
+          b: d
+        });
+      }
 
-    var vis = new candela.components.LineChart(el, {
-      data: data, x: 'a', y: ['b'],
-      width: 700, height: 400
-    });
-    vis.render();
+      var vis = new candela.components.LineChart(el, {
+        data: data,
+        x: 'a',
+        y: ['b'],
+        width: 700,
+        height: 400
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/linechart.rst
+++ b/docs/components/linechart.rst
@@ -28,7 +28,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/linechart.rst
+++ b/docs/components/linechart.rst
@@ -23,28 +23,13 @@ Example
       vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import LineChart from candela.components.LineChart
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
-
-    let vis = new LineChart(el, {
-      data: data, x: 'a', y: ['b'],
-      width: 700, height: 400
-    });
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
@@ -56,6 +41,8 @@ Example
       width: 700, height: 400
     });
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/lineup.rst
+++ b/docs/components/lineup.rst
@@ -28,7 +28,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/lineup.rst
+++ b/docs/components/lineup.rst
@@ -23,25 +23,13 @@ Example
         vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import LineUp from candela.components.LineUp
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: 10 - d, name: d});
-
-    let vis = new LineUp(el, {data: data, fields: ['a', 'b']});
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
@@ -51,6 +39,8 @@ Example
     var vis = new candela.components.LineUp(el, {
       data: data, fields: ['a', 'b']});
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/lineup.rst
+++ b/docs/components/lineup.rst
@@ -30,15 +30,23 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: 10 - d, name: d});
+      var data = [];
+      for (var d = 0; d < 10; d += 1) {
+        data.push({
+          a: d,
+          b: 10 - d,
+          name: d
+        });
+      }
 
-    var vis = new candela.components.LineUp(el, {
-      data: data, fields: ['a', 'b']});
-    vis.render();
+      var vis = new candela.components.LineUp(el, {
+        data: data,
+        fields: ['a', 'b']
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/scatterplot.rst
+++ b/docs/components/scatterplot.rst
@@ -31,7 +31,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/scatterplot.rst
+++ b/docs/components/scatterplot.rst
@@ -33,17 +33,25 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
+      var data = [];
+      for (var d = 0; d < 10; d += 1) {
+        data.push({
+          a: d,
+          b: d
+        });
+      }
 
-    var vis = new candela.components.ScatterPlot(el, {
-      data: data, x: 'a', y: 'b',
-      width: 700, height: 400
-    });
-    vis.render();
+      var vis = new candela.components.ScatterPlot(el, {
+        data: data,
+        x: 'a',
+        y: 'b',
+        width: 700,
+        height: 400
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/scatterplot.rst
+++ b/docs/components/scatterplot.rst
@@ -26,28 +26,13 @@ Example
       vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import ScatterPlot from candela.components.ScatterPlot
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: d});
-
-    let vis = new ScatterPlot(el, {
-      data: data, x: 'a', y: 'b',
-      width: 700, height: 400
-    });
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
@@ -59,6 +44,8 @@ Example
       width: 700, height: 400
     });
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/components/scatterplotmatrix.rst
+++ b/docs/components/scatterplotmatrix.rst
@@ -28,7 +28,7 @@ Example
 .. code-block:: html
 
     <body>
-    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <script>
     var el = document.createElement('div')
     document.body.appendChild(el);

--- a/docs/components/scatterplotmatrix.rst
+++ b/docs/components/scatterplotmatrix.rst
@@ -30,15 +30,23 @@ Example
     <body>
     <script src="//unpkg.com/candela"></script>
     <script>
-    var el = document.createElement('div')
-    document.body.appendChild(el);
+      var el = document.createElement('div')
+      document.body.appendChild(el);
 
-    var data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: 10 - d, name: d});
+      var data = [];
+      for (var d = 0; d < 10; d += 1) {
+        data.push({
+          a: d,
+          b: 10 - d,
+          name: d
+        });
+      }
 
-    var vis = new candela.components.ScatterPlotMatrix(el, {
-      data: data, fields: ['a', 'b']});
-    vis.render();
+      var vis = new candela.components.ScatterPlotMatrix(el, {
+        data: data,
+        fields: ['a', 'b']
+      });
+      vis.render();
     </script>
     </body>
 

--- a/docs/components/scatterplotmatrix.rst
+++ b/docs/components/scatterplotmatrix.rst
@@ -23,25 +23,13 @@ Example
         vis.render();
     </script>
 
-**ES6/Webpack**
+**JavaScript**
 
-.. code-block:: js
+.. code-block:: html
 
-    import ScatterPlotMatrix from candela.components.ScatterPlotMatrix
-
-    let el = document.createElement('div');
-    document.body.appendChild(el);
-
-    let data = [];
-    for (var d = 0; d < 10; d += 1) data.push({a: d, b: 10 - d, name: d});
-
-    let vis = new ScatterPlotMatrix(el, {data: data, fields: ['a', 'b']});
-    vis.render();
-
-**ES5**
-
-.. code-block:: js
-
+    <body>
+    <script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script>
     var el = document.createElement('div')
     document.body.appendChild(el);
 
@@ -51,6 +39,8 @@ Example
     var vis = new candela.components.ScatterPlotMatrix(el, {
       data: data, fields: ['a', 'b']});
     vis.render();
+    </script>
+    </body>
 
 **Python**
 

--- a/docs/static/index.html
+++ b/docs/static/index.html
@@ -3,18 +3,20 @@
 <script src="//unpkg.com/candela"></script>
 <script>
 
-var data = [
+  var data = [
     {x: 1, y: 3},
     {x: 2, y: 4},
     {x: 2, y: 3},
     {x: 0, y: 1}
-];
+  ];
 
-var el = document.getElementById('vis');
-var vis = new candela.components.ScatterPlot(el, {
-  data: data, x: 'x', y: 'y'
-});
-vis.render();
+  var el = document.getElementById('vis');
+  var vis = new candela.components.ScatterPlot(el, {
+    data: data,
+    x: 'x',
+    y: 'y'
+  });
+  vis.render();
 
 </script>
 </body>

--- a/docs/static/index.html
+++ b/docs/static/index.html
@@ -1,6 +1,6 @@
 <body>
 <div id="vis"></div>
-<script src="http://kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+<script src="//unpkg.com/candela"></script>
 <script>
 
 var data = [

--- a/docs/templates/layout.html
+++ b/docs/templates/layout.html
@@ -1,7 +1,7 @@
 {% extends "!layout.html" %}
 
 {%- block extrahead %}
-    <script src="//kitware.github.io/candela/candela-0.2.0-81be44f6.js"></script>
+    <script src="//unpkg.com/candela"></script>
     <style>
     /* This is a hack because Candela currently leaks global CSS. */
     /* We should able to remove this when that issue is resolved. */

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "codecov.io": "^0.1.6",
     "copy-webpack-plugin": "^1.1.1",
     "css-loader": "^0.23.1",
+    "cz-conventional-changelog": "^1.2.0",
     "eslint": "^1.10.3",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-promise": "^1.0.8",
@@ -122,5 +123,10 @@
     "jquery-deparam": "^0.5.2",
     "underscore": "^1.8.3",
     "vega": "^2.4.2"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
Fixes #401. Waiting for better CDN of candela so that we can replace links with ones that will point to the latest candela.