### PR TITLE
Make travis build both correct and performant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ addons:
             - g++-4.8
             - libgif-dev
 
+cache:
+    directories:
+        - node_modules
+
 before_install:
     - npm i -g npm@^2.0.0
     - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ script:
     - npm run codecov
 
 after_success:
+    - npm run dist
     - npm run semantic-release


### PR DESCRIPTION
- Correct: Travis needs to build the distribution files before performing a semantic release
- Performant: Caching the node_modules should shave several minutes off the build time

Closes #429 