### PR TITLE
chore(resonantlab): Point to candela docs from vis selector

### DIFF
--- a/app/resonantlab/views/overlays/VisualizationLibrary/index.js
+++ b/app/resonantlab/views/overlays/VisualizationLibrary/index.js
@@ -46,6 +46,13 @@ let VisualizationLibrary = Backbone.View.extend({
     libraryButtons.select('span')
       .text(d => d.name);
 
+    libraryButtonsEnter.append('a');
+    libraryButtons.select('a')
+      .attr('href', d => 'https://candela.readthedocs.io/en/latest/components/' + d.name.toLowerCase() + '.html')
+      .attr('target', '_blank')
+      .text('info')
+      .on('click', () => d3.event.stopPropagation());
+
     d3.select('div.largeDialog').selectAll('.circleButton')
       .on('click', d => {
         window.mainPage.getProject().then(project => {


### PR DESCRIPTION
Fixes #247

This is a start that is not super pretty but at least lets the user go to the docs to find out more about each vis type.