### PR TITLE
Pin pycparser to 2.14 to avoid regex error in bad 2.15 wheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
     - sh -e /etc/init.d/xvfb start
 
 install:
+    - pip install --user pycparser==2.14
     - pip install --user girder-client 'requests[security]'
     - pip install --user flake8
 


### PR DESCRIPTION
Some background:
- https://github.com/pyca/cryptography/issues/3187
- https://github.com/eliben/pycparser/issues/151

And here's a fixed Travis build from this branch: https://travis-ci.org/Kitware/candela/builds/168639954