### PR TITLE
Add polyfill to support IE

### DIFF
--- a/app/resonantlab/mainPage.js
+++ b/app/resonantlab/mainPage.js
@@ -1,3 +1,5 @@
+import 'babel-polyfill';
+
 import Backbone from 'backbone';
 import d3 from 'd3';
 import is from 'is_js';

--- a/app/resonantlab/webpack.config.js
+++ b/app/resonantlab/webpack.config.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var webpack = require('webpack');
 var GruntWatchPlugin = require('./grunt-watch-plugin.js');
 
-var entry = ['./mainPage.js'];
+var entry = ['babel-polyfill', './mainPage.js'];
 
 var gaKey = process.env.GOOGLE_ANALYTICS_KEY;
 if (gaKey) {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "babel-core": "^6.4.5",
     "babel-istanbul-loader": "^0.1.0",
     "babel-loader": "^6.2.1",
-    "babel-polyfill": "^6.9.0",
+    "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.3.13",
     "backbone": "^1.2.3",
     "bluebird": "^3.3.5",


### PR DESCRIPTION
Fixes #458 

Now at least MS Edge and IE 11 will render enough to see the warning message that the browser is not supported. Before this the app hit an error on IE 11 ("Symbol" type was not defined). Both browsers are now able to see and configure a simple plot with this fix, but the dataset panel is non-functional. I followed instructions at https://babeljs.io/docs/usage/polyfill/.

Edge:
![screen shot 2016-10-21 at 2 39 12 pm](https://cloud.githubusercontent.com/assets/81305/19608599/684c9a54-97a0-11e6-9cb8-d345f8016fff.png)

IE 11:
![screen shot 2016-10-21 at 3 09 09 pm](https://cloud.githubusercontent.com/assets/81305/19608589/5c7bbee4-97a0-11e6-809c-127ed885f640.png)

