### PR TITLE
Remove black markerline from trackerdash

### DIFF
--- a/src/candela/components/TrackerDash/ErrorBulletWidget.js
+++ b/src/candela/components/TrackerDash/ErrorBulletWidget.js
@@ -23,7 +23,8 @@ class ErrorBulletWidget extends VisComponent {
   chartData () {
     return {
       ranges: this.trend.incompleteThreshold ? [0, 0, this.trend.max] : [this.trend.warning, this.trend.fail, this.trend.max],
-      measures: [Math.round(Math.min(this.result.current, this.trend.max) * 10000) / 10000]
+      measures: [Math.round(Math.min(this.result.current, this.trend.max) * 10000) / 10000],
+      markerLines: []
     };
   }
 


### PR DESCRIPTION
Turns this

<img width="177" alt="screen shot 2016-12-08 at 3 10 38 pm" src="https://cloud.githubusercontent.com/assets/595023/21025981/a7946d30-bd58-11e6-945b-bc0d1d5721f8.png">


into this

<img width="177" alt="screen shot 2016-12-08 at 3 11 07 pm" src="https://cloud.githubusercontent.com/assets/595023/21025975/9f3026c0-bd58-11e6-98e9-e64d817718c8.png">
