### PR TITLE
Fix autoresize problem in VegaCharts

### DIFF
--- a/VisComponent/mixin/VegaChart.js
+++ b/VisComponent/mixin/VegaChart.js
@@ -8,7 +8,17 @@ let VegaChart = (Base, spec) => class extends Base {
   }
 
   render () {
-    this.chart.then(chart => chart.update());
+    this.chart.then(chart => {
+      if (this.width) {
+        chart = chart.width(this.width);
+      }
+
+      if (this.height) {
+        chart = chart.height(this.height);
+      }
+
+      chart.update();
+    });
   }
 
   get serializationFormats () {


### PR DESCRIPTION
Vega has a way to update the width and height of a chart on render, without recompiling from the spec. `VegaChart` now takes advantage of it, restoring the `AutoResize` functionality in the demos.