### PR TITLE
Enable semantic-release on Circle

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "clean-webpack-plugin": "^0.1.7",
     "codecov.io": "^0.1.6",
     "commitizen": "^2.8.6",
+    "condition-circle": "^1.5.0",
     "conventional-commit-types": "^2.1.0",
     "copy-webpack-plugin": "^1.1.1",
     "cz-conventional-changelog": "^1.2.0",
@@ -148,5 +149,8 @@
     "validate-commit-msg": {
       "helpMessage": "This project is commitizen-friendly.\nLearn more at https://commitizen.github.io/cz-cli/https://commitizen.github.io/cz-cli/\nTo try again, you can say \"git commit -t .git/COMMIT_EDITMSG\".\nOr, you can use git-cz to make your commits."
     }
+  },
+  "release": {
+    "verifyConditions": "condition-circle"
   }
 }


### PR DESCRIPTION
It turns out semantic-release only runs on Travis by default - this PR uses a plugin to change the conditions under which it will run, so that it recognizes Circle as a valid host for performing releases.

Unfortunately the only way to "test" this is to merge it to master and check the Circle logs to see if semantic-release actually runs (even then, it won't result in a release from this PR, since it's only a `ci` change).