### PR TITLE
Fix SimiliarityGraph docs

### DIFF
--- a/docs/components/similaritygraph.rst
+++ b/docs/components/similaritygraph.rst
@@ -24,7 +24,7 @@ Example
 
 .. raw:: html
 
-    <svg id="similaritygraph-example" width="700" height="700"></svg>
+    <div id="similaritygraph-example" width="700" height="700"></svg>
     <script type="text/javascript" >
       var el = document.getElementById('similaritygraph-example');
 
@@ -61,7 +61,7 @@ Example
     <body>
     <script src="/static/candela.js"></script>
     <script>
-      var el = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      var el = document.createElement('div')
       el.setAttribute('width', 700);
       el.setAttribute('width', 700);
 

--- a/docs/components/similaritygraph.rst
+++ b/docs/components/similaritygraph.rst
@@ -24,7 +24,7 @@ Example
 
 .. raw:: html
 
-    <div id="similaritygraph-example" width="700" height="700"></svg>
+    <div id="similaritygraph-example" width="700" height="700"></div>
     <script type="text/javascript" >
       var el = document.getElementById('similaritygraph-example');
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,6 +120,7 @@ Quick start - R
     components/onset
     components/scatterplot
     components/scatterplotmatrix
+    components/similaritygraph
     components/survivalplot
     components/upset
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "clean-webpack-plugin": "^0.1.7",
     "codecov.io": "^0.1.6",
     "commitizen": "^2.8.6",
+    "condition-circle": "^1.5.0",
     "conventional-commit-types": "^2.1.0",
     "copy-webpack-plugin": "^1.1.1",
     "cz-conventional-changelog": "^1.2.0",
@@ -148,5 +149,8 @@
     "validate-commit-msg": {
       "helpMessage": "This project is commitizen-friendly.\nLearn more at https://commitizen.github.io/cz-cli/https://commitizen.github.io/cz-cli/\nTo try again, you can say \"git commit -t .git/COMMIT_EDITMSG\".\nOr, you can use git-cz to make your commits."
     }
+  },
+  "release": {
+    "verifyConditions": "condition-circle"
   }
 }


### PR DESCRIPTION
- Use a `div` instead of an `svg` in the doc example
- Add a pointer to the documentation front page to the SimilarityGraph docs

Depends on #483 to enable proper CI.