### PR TITLE
Swallow errors from `npm run semantic-release`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -47,4 +47,4 @@ deployment:
     branch: master
     commands:
       - npm run dist
-      - npm run semantic-release
+      - npm run semantic-release || true


### PR DESCRIPTION
This is done because technically, semantic-release fails with non-zero
exit code on ENOCHANGE, which is the error code generated when there is
nothing to actually release (i.e., if there are no `feat` or `fix`
commit tags).

Travis gets around this by not failing the entire build if the
`after_success` step fails; in Circle we're using the deployment step
for this, which *does* fail the whole build if it fails.