### PR TITLE
Add update / destroy API for VisComponent

### DIFF
--- a/VisComponent/index.js
+++ b/VisComponent/index.js
@@ -9,14 +9,22 @@ export default class VisComponent {
     this.el = el;
   }
 
+  render () {
+    throw new Error('"render() is pure abstract"');
+  }
+
+  update () {
+    throw new Error('"update() is pure abstract"');
+  }
+
+  destroy () {
+    throw new Error('"destroy()" is pure abstract"');
+  }
+
   empty () {
     select(this.el)
       .selectAll('*')
       .remove();
-  }
-
-  render () {
-    throw new Error('"render() is pure abstract"');
   }
 
   get serializationFormats () {

--- a/VisComponent/index.js
+++ b/VisComponent/index.js
@@ -13,7 +13,9 @@ export default class VisComponent {
     throw new Error('"render() is pure abstract"');
   }
 
-  update () {}
+  update () {
+    return Promise.resolve(this);
+  }
 
   destroy () {
     this.empty();

--- a/VisComponent/index.js
+++ b/VisComponent/index.js
@@ -1,3 +1,5 @@
+import { select } from 'd3-selection';
+
 export default class VisComponent {
   constructor (el) {
     if (!el) {
@@ -5,6 +7,12 @@ export default class VisComponent {
     }
 
     this.el = el;
+  }
+
+  empty () {
+    select(this.el)
+      .selectAll('*')
+      .remove();
   }
 
   render () {

--- a/VisComponent/index.js
+++ b/VisComponent/index.js
@@ -13,12 +13,10 @@ export default class VisComponent {
     throw new Error('"render() is pure abstract"');
   }
 
-  update () {
-    throw new Error('"update() is pure abstract"');
-  }
+  update () {}
 
   destroy () {
-    throw new Error('"destroy()" is pure abstract"');
+    this.empty();
   }
 
   empty () {

--- a/VisComponent/mixin/VegaChart.js
+++ b/VisComponent/mixin/VegaChart.js
@@ -8,7 +8,7 @@ let VegaChart = (Base, spec) => class extends Base {
   }
 
   render () {
-    this.chart.then(chart => {
+    return this.chart.then(chart => {
       if (this.width) {
         chart = chart.width(this.width);
       }
@@ -28,7 +28,7 @@ let VegaChart = (Base, spec) => class extends Base {
 
     if (this.options.data) {
       promise = promise.then(chart => {
-        chart.data('data')
+        return chart.data('data')
           .remove(() => true)
           .insert(this.options.data);
       });

--- a/VisComponent/mixin/VegaChart.js
+++ b/VisComponent/mixin/VegaChart.js
@@ -21,6 +21,35 @@ let VegaChart = (Base, spec) => class extends Base {
     });
   }
 
+  update (options) {
+    let promise = this.chart;
+
+    Object.assign(this.options, options);
+
+    if (this.options.data) {
+      promise = promise.then(chart => {
+        chart.data('data')
+          .remove(() => true)
+          .insert(this.options.data);
+      });
+    }
+
+    if (this.options.width) {
+      this.width = this.options.width;
+    }
+
+    if (this.options.height) {
+      this.height = this.options.height;
+    }
+
+    return promise;
+  }
+
+  destroy () {
+    this.empty();
+    delete this.chart;
+  }
+
   get serializationFormats () {
     return ['png', 'svg'];
   }

--- a/app/examples/dynamic-linechart/index.js
+++ b/app/examples/dynamic-linechart/index.js
@@ -12,18 +12,6 @@ class DynamicLineChart extends LineChart {
     super.render();
     this.emit('render');
   }
-
-  data (data) {
-    this.options.data = data;
-
-    this.chart.then(chart => {
-      let data = chart.data('data');
-      data.remove(() => true);
-      data.insert(this.options.data);
-
-      chart.update();
-    });
-  }
 }
 
 let data = [];
@@ -58,7 +46,7 @@ window.onload = () => {
 
     counter++;
 
-    vis.data(data);
+    vis.update({data});
     vis.render();
   }, 1000);
 

--- a/app/examples/geodots/index.js
+++ b/app/examples/geodots/index.js
@@ -11,14 +11,15 @@ window.onload = () => {
     longitude: 'longitude',
     latitude: 'latitude',
     data: [
-      {id: 0, longitude: -87.578, latitude: 41.838, c: 3},
-      {id: 1, longitude: -87.644, latitude: 41.702, c: 3},
-      {id: 2, longitude: -87.693, latitude: 41.617, c: 3},
-      {id: 3, longitude: -87.708, latitude: 41.953, c: 3},
-      {id: 4, longitude: -87.700, latitude: 41.747, c: 3},
-      {id: 5, longitude: -87.555, latitude: 41.806, c: 3},
-      {id: 6, longitude: -87.335, latitude: 42.039, c: 3},
-      {id: 7, longitude: -87.313, latitude: 41.615, c: 3}
+      {id: 10, longitude: -20, latitude: 10, c: 'A'},
+      {id: 0, longitude: -87.578, latitude: 41.838, c: 'B'},
+      {id: 1, longitude: -87.644, latitude: 41.702, c: 'A'},
+      {id: 2, longitude: -87.693, latitude: 41.617, c: 'B'},
+      {id: 3, longitude: -87.708, latitude: 41.953, c: 'A'},
+      {id: 4, longitude: -87.700, latitude: 41.747, c: 'B'},
+      {id: 5, longitude: -87.555, latitude: 41.806, c: 'A'},
+      {id: 6, longitude: -87.335, latitude: 42.039, c: 'B'},
+      {id: 7, longitude: -87.313, latitude: 41.615, c: 'C'}
     ]
   });
 };

--- a/components/BarChart/test/barchart.js
+++ b/components/BarChart/test/barchart.js
@@ -1,0 +1,68 @@
+import { select } from 'd3-selection';
+import test from 'tape-catch';
+
+import BarChart from '..';
+
+test('BarChart component', t => {
+  t.plan(7);
+
+  const data = [
+    {id: 0, a: 1, b: 3, c: 3},
+    {id: 1, a: 10, b: 4, c: 3},
+    {id: 2, a: 7, b: 6, c: 3},
+    {id: 3, a: 4, b: 2, c: 3},
+    {id: 4, a: 5, b: 5, c: 3},
+    {id: 5, a: 7, b: 6, c: 3},
+    {id: 6, a: 2, b: 9, c: 3},
+    {id: 7, a: 5, b: 7, c: 3}
+  ];
+
+  let el = document.createElement('div');
+  let vis = new BarChart(el, {
+    data: data,
+    x: 'id',
+    y: 'a',
+    color: 'b',
+    width: 625,
+    height: 540,
+    padding: {
+      left: 45,
+      right: 130,
+      top: 20,
+      bottom: 40
+    },
+    renderer: 'svg'
+  });
+
+  vis.chart.then(() => {
+    t.equal(el.childNodes.length, 1, 'VegaCharts should have a single element under the top-level div');
+
+    let container = el.childNodes[0];
+    t.equal(container.nodeName, 'DIV', 'The single element should be a div');
+    t.equal(container.childNodes.length, 1, 'The div should have a single child element.');
+
+    let svg = container.childNodes[0];
+    t.equal(svg.nodeName, 'svg', 'The single child should be an svg.');
+
+    let bars = select(svg)
+      .select('g.mark-rect')
+      .selectAll('rect');
+    t.equal(bars.size(), data.length, 'The number of bars in the chart should equal the number of data items');
+
+    vis.update({
+      data: data.concat([{id: 8, a: 10, b: 6, c: 3}])
+    }).then(() => vis.render())
+    .then(() => {
+      vis.render();
+
+      bars = select(svg)
+        .select('g.mark-rect')
+        .selectAll('rect');
+      t.equal(bars.size(), data.length + 1, 'After data update, the number of bars in the chart should equal the original number of data items, plus one');
+
+      vis.destroy();
+      let contents = select(vis.el).selectAll('*');
+      t.equal(contents.size(), 0, 'After destroy(), container element should have no children');
+    });
+  });
+});

--- a/components/Geo/index.js
+++ b/components/Geo/index.js
@@ -17,10 +17,11 @@ export default class Geo extends VisComponent {
     }, map));
 
     // Process the requested layers.
+    this.layers = [];
     layers.forEach(layer => {
       switch (layer.type) {
         case 'osm':
-          this.plot.createLayer('osm', layer);
+          this.layers.push(this.plot.createLayer('osm', layer));
           break;
 
         case 'feature':
@@ -41,6 +42,8 @@ export default class Geo extends VisComponent {
             }, spec.style);
 
             feature.style(style);
+
+            this.layers.push(feature);
           });
           break;
       }

--- a/components/GeoDots/index.js
+++ b/components/GeoDots/index.js
@@ -202,5 +202,7 @@ export default class GeoDots extends VisComponent {
     if (changed.size > 0) {
       points.modified();
     }
+
+    return Promise.resolve(this);
   }
 }

--- a/components/GeoDots/index.js
+++ b/components/GeoDots/index.js
@@ -1,7 +1,62 @@
-import d3 from 'd3';
+import d3 from 'geojs/node_modules/d3';
 import Geo from '../Geo';
 import VisComponent from '../../VisComponent';
 import { minmax } from '../../util';
+
+const computeSizeTransform = (data, sizeField) => {
+  let sizeTransform = 5;
+  if (sizeField) {
+    const range = minmax(data.map(d => d[sizeField]));
+    const scale = d3.scale.linear()
+      .domain([range.min, range.max])
+      .range([3, 19]);
+
+    sizeTransform = d => scale(d[sizeField]);
+  }
+
+  return sizeTransform;
+};
+
+const computeColorTransforms = (data, color) => {
+  let fillTransform = 'red';
+  let strokeTransform = 'darkred';
+  if (color && data.length > 0) {
+    let fillScale, strokeScale;
+
+    const type = typeof data[0][color];
+    if (type === undefined || type === 'string') {
+      fillScale = d3.scale.category10();
+      strokeScale = 'black';
+    } else {
+      const range = minmax(data.map(d => d[color]));
+
+      const red = d3.rgb('#ef6a62');
+      const blue = d3.rgb('#67a9cf');
+      const darkred = red.darker();
+      const darkblue = blue.darker();
+
+      fillScale = d3.scale.linear()
+        .domain([range.min, range.max])
+        .range([red, blue]);
+
+      strokeScale = d3.scale.linear()
+        .domain([range.min, range.max])
+        .range([darkred, darkblue]);
+    }
+
+    fillTransform = d => fillScale(d[color]);
+    if (strokeScale === 'black') {
+      strokeTransform = 'black';
+    } else {
+      strokeTransform = d => strokeScale(d[color]);
+    }
+  }
+
+  return {
+    fillTransform,
+    strokeTransform
+  };
+};
 
 export default class GeoDots extends VisComponent {
   static get options () {
@@ -65,49 +120,8 @@ export default class GeoDots extends VisComponent {
     el.style.width = width + 'px';
     el.style.height = height + 'px';
 
-    let sizeTransform = 5;
-    if (options.size) {
-      const range = minmax(options.data.map(d => d[options.size]));
-      const scale = d3.scale.linear()
-        .domain([range.min, range.max])
-        .range([3, 19]);
-
-      sizeTransform = d => scale(d[options.size]);
-    }
-
-    let fillTransform = 'red';
-    let strokeTransform = 'darkred';
-    if (options.color && options.data.length > 0) {
-      let fillScale, strokeScale;
-
-      const type = typeof options.data[0][options.color];
-      if (type === undefined || type === 'string') {
-        fillScale = d3.scale.category10();
-        strokeScale = 'black';
-      } else {
-        const range = minmax(options.data.map(d => d[options.color]));
-
-        const red = d3.rgb('#ef6a62');
-        const blue = d3.rgb('#67a9cf');
-        const darkred = red.darker();
-        const darkblue = blue.darker();
-
-        fillScale = d3.scale.linear()
-          .domain([range.min, range.max])
-          .range([red, blue]);
-
-        strokeScale = d3.scale.linear()
-          .domain([range.min, range.max])
-          .range([darkred, darkblue]);
-      }
-
-      fillTransform = d => fillScale(d[options.color]);
-      if (strokeScale === 'black') {
-        strokeTransform = 'black';
-      } else {
-        strokeTransform = d => strokeScale(d[options.color]);
-      }
-    }
+    const sizeTransform = computeSizeTransform(options.data, options.size);
+    const { fillTransform, strokeTransform } = computeColorTransforms(options.data, options.color);
 
     // TODO(choudhury): don't mutate the options object directly.
     options.layers = [];
@@ -150,9 +164,43 @@ export default class GeoDots extends VisComponent {
     }, options);
 
     this.geojs = new Geo(this.el, map_options);
+    this.options = options;
   }
 
   render () {
     this.geojs.render();
+  }
+
+  update (options) {
+    let points = this.geojs.layers[1];
+
+    let changed = new Set();
+    ['longitude', 'latitude', 'color', 'size'].forEach(opt => {
+      if (options[opt]) {
+        changed.add(opt);
+        this.options[opt] = options[opt];
+      }
+    });
+
+    if (changed.has('longitude') || changed.has('latitude')) {
+      points.position(d => ({
+        x: d[this.options.longitude],
+        y: d[this.options.latitude]
+      }));
+    }
+
+    if (changed.has('size')) {
+      points.style('radius', computeSizeTransform(this.options.data, this.options.size));
+    }
+
+    if (changed.has('color')) {
+      const { fillTransform, strokeTransform } = computeColorTransforms(this.options.data, this.options.color);
+      points.style('fillColor', fillTransform)
+        .style('strokeColor', strokeTransform);
+    }
+
+    if (changed.size > 0) {
+      points.modified();
+    }
   }
 }

--- a/components/SentenTree/index.js
+++ b/components/SentenTree/index.js
@@ -1,5 +1,3 @@
-import { select } from 'd3-selection';
-
 import VisComponent from '../../VisComponent';
 import { SentenTreeBuilder,
          SentenTreeVis } from 'sententree/dist/SentenTree';
@@ -57,9 +55,7 @@ export default class SentenTree extends VisComponent {
     super(el);
 
     // Empty element.
-    select(el)
-      .selectAll('*')
-      .remove();
+    this.empty();
 
     // Transform input data into correct form.
     this.data = data.map((d, i) => ({

--- a/components/SimilarityGraph/index.js
+++ b/components/SimilarityGraph/index.js
@@ -9,8 +9,7 @@ export default class SimilarityGraph extends VisComponent {
     this.data = data;
 
     // Empty the top-level div.
-    d3.select(this.el)
-      .selectAll('*').remove();
+    this.empty();
 
     // Construct an SVG element inside the top-level div.
     this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');

--- a/components/TreeHeatmap/index.js
+++ b/components/TreeHeatmap/index.js
@@ -98,7 +98,7 @@ export default class TreeHeatmap extends VisComponent {
   }
 
   render () {
-    d3.select(this.el).selectAll('*').remove();
+    this.empty();
 
     if (this.data === undefined || this.data.length === 0) {
       return;

--- a/docs/candela-js.rst
+++ b/docs/candela-js.rst
@@ -97,6 +97,16 @@ features of all Candela components:
    :ref:`render <render>` method. The base class :ref:`render <render>`
    simply raises an exception.
 
+3. Sometimes you need to change an aspect of the visualization at runtime, such
+   as the color map, which columns of data are being visualized, or even the
+   data itself; to support such changes, Candela components have an :ref:`update
+   <update>` method. The base class :ref:`update <update>` is a no-op.
+
+4. When a visualization component reaches the end of its lifecycle, it may need
+   to clean up after itself, which can be done in the component's :ref:`destroy
+   <destroy>` method. The base class :ref:`destroy <destroy>` simply removes all
+   content from `this.el`.
+
 You can create a concrete visualization component by extending ``VisComponent``.
 The following best practices maximize clarity, reusability, and interoperability
 of your components (in the rest of this document, imagine that ``Component``
@@ -133,6 +143,36 @@ is declared as an extension of ``VisComponent``, such as ``BarChart``):
     **Note**: The ``VisComponent`` ``render()`` method simply throws
     an exception; if you truly want your component to do nothing when it renders,
     simply redefine the method to be a no-op.
+
+.. _update:
+
+.. js:function:: component.update(options)
+
+    Changes the component state to reflect `options`. This method allows for
+    incremental changes to the component state. The form of `options` should be
+    the same as what the :ref:`constructor <constructor>` takes. The difference
+    is, only the options given to this method should change, while any left
+    unspecified should remain as they are.
+
+    **Note**: The ``VisComponent`` ``update()`` method is a no-op, since the
+    semantics of updating will be different for every component.
+
+.. _destroy:
+
+.. js:function:: component.destroy()
+
+    Performs any cleanup required of the component when it is no longer needed.
+    This may be as simple as emptying the container element the component has
+    been using, or it may involve unregistering event listeners, etc.
+
+    **Note**: The ``VisComponent`` ``destroy()`` method just empties the
+    top-level container, since this is a common "cleanup" operation.
+
+.. js:function:: component.empty()
+
+    Convenience method that empties the component's container element. This can
+    be used in the constructor to prepare the container element, or in the
+    :ref:`destroy <destroy>` method to clean up after the component.
 
 .. js:attribute:: component.serializationFormats
 

--- a/docs/candela-js.rst
+++ b/docs/candela-js.rst
@@ -100,7 +100,8 @@ features of all Candela components:
 3. Sometimes you need to change an aspect of the visualization at runtime, such
    as the color map, which columns of data are being visualized, or even the
    data itself; to support such changes, Candela components have an :ref:`update
-   <update>` method. The base class :ref:`update <update>` is a no-op.
+   <update>` method. The base class :ref:`update <update>` returns a promise
+   object that delivers the component itself.
 
 4. When a visualization component reaches the end of its lifecycle, it may need
    to clean up after itself, which can be done in the component's :ref:`destroy
@@ -154,8 +155,9 @@ is declared as an extension of ``VisComponent``, such as ``BarChart``):
     is, only the options given to this method should change, while any left
     unspecified should remain as they are.
 
-    **Note**: The ``VisComponent`` ``update()`` method is a no-op, since the
-    semantics of updating will be different for every component.
+    **Note**: The ``VisComponent`` ``update()`` method returns a promise object
+    that delivers the component itself without changing it, since the semantics
+    of updating will be different for every component.
 
 .. _destroy:
 

--- a/package.json
+++ b/package.json
@@ -36,12 +36,9 @@
   "semistandard": {
     "ignore": [
       "config",
-      "src/external",
-      "app/resonantlab/gaTemplate.js",
-      "app/resonantlab/ga.js",
-      "app/resonantlab/web_client/lib",
+      "app/resonantlab",
       "dist",
-      "built",
+      "build",
       "R/candela/inst/htmlwidgets/lib"
     ]
   },


### PR DESCRIPTION
TODO:
- [x] make GeoDots (and other GeoJS based components) use update API to fix "reset-to-0,0" bug
- [x] write documentation for new API methods

This PR adds `update()` and `destroy()` methods to `VisComponent`, allowing for in-place updates and cleanup upon destroying a component. These should make component lifecycles more explicit and manageable in automated contexts such as Resonant Lab and the Candela plugin for Girder.

Note that this now completes a sort of "CRUD" model for `VisComponent`: create == `constructor()`, read == `render()`, update == `update()`, and delete == `destroy()`. In particular, this means that `render()` should really just take the state of a component and make it visible - nothing more or less than that. Whether this is a valid model we want to officially promote for components is something that remains to discuss.