### PR TITLE
Use HTTPS to include candela.min.js in R

### DIFF
--- a/R/candela/inst/htmlwidgets/lib/candela/candela.js
+++ b/R/candela/inst/htmlwidgets/lib/candela/candela.js
@@ -1,4 +1,4 @@
 var s = document.createElement('script');
 s.type = 'text/javascript';
-s.src = '//unpkg.com/candela/dist/candela.min.js';
+s.src = 'https://unpkg.com/candela/dist/candela.min.js';
 document.head.appendChild(s);


### PR DESCRIPTION
When exporting a markdown file, using `//unpkg...` will incorrectly get interpreted as `file://unpkg...`.