### PR TITLE
Revert "fix(build): Fixes broken build by ensuring new vega-canvas is not depended on"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13006,31 +13006,32 @@
       }
     },
     "vega": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-3.0.5.tgz",
-      "integrity": "sha512-z0YtMYfnlynljAvaPkBPa/ko2AUTdC32ZlTM5VVYuL88O3XAPINwaxXhqWvDC/SMP7NHoB1lK2OuBJ8OAG8UcA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-3.0.10.tgz",
+      "integrity": "sha512-Ol9tq4sn2yo3DkOt8pjgqCyxJcOsdvO5ZKEDSzCPf3iyQXSAXbbARn+TcOguelPBgnyYBOtyfrZFo5TJNDzRjg==",
       "requires": {
+        "canvas": "1.6.5",
+        "canvas-prebuilt": "1.6.0",
         "vega-crossfilter": "2.0.0",
         "vega-dataflow": "3.0.3",
-        "vega-datasets": "github:vega/vega-datasets#080684168d273c6893d67c47630bc68dce4a53b7",
         "vega-encode": "2.0.4",
         "vega-expression": "2.3.1",
         "vega-force": "2.0.0",
         "vega-geo": "2.1.1",
         "vega-hierarchy": "2.1.0",
         "vega-loader": "2.0.2",
-        "vega-parser": "2.2.0",
+        "vega-parser": "2.4.0",
         "vega-projection": "1.0.0",
         "vega-runtime": "2.0.0",
         "vega-scale": "2.1.0",
-        "vega-scenegraph": "2.0.3",
+        "vega-scenegraph": "2.2.0",
         "vega-statistics": "1.2.1",
         "vega-transforms": "1.1.1",
         "vega-util": "1.6.0",
-        "vega-view": "2.0.3",
+        "vega-view": "2.1.0",
         "vega-view-transforms": "1.1.0",
         "vega-voronoi": "2.0.0",
-        "vega-wordcloud": "2.0.2",
+        "vega-wordcloud": "2.1.0",
         "yargs": "4.8.1"
       },
       "dependencies": {
@@ -13049,8 +13050,60 @@
             "wrap-ansi": "2.1.0"
           }
         },
-        "vega-datasets": {
-          "version": "github:vega/vega-datasets#080684168d273c6893d67c47630bc68dce4a53b7"
+        "vega-parser": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-2.4.0.tgz",
+          "integrity": "sha512-cGifhO5R9MF2PfaiwKBmMsVMzOk9+cvjsTGwnVcFSjoDSV2FmgxYIotcinS0Dt1rmPKhukeP0RMeUekqGU7hDQ==",
+          "requires": {
+            "d3-array": "1.2.0",
+            "d3-color": "1.0.3",
+            "d3-format": "1.2.0",
+            "d3-time-format": "2.0.5",
+            "vega-dataflow": "3.0.3",
+            "vega-event-selector": "2.0.0",
+            "vega-expression": "2.3.1",
+            "vega-scale": "2.1.0",
+            "vega-scenegraph": "2.2.0",
+            "vega-statistics": "1.2.1",
+            "vega-util": "1.6.0"
+          }
+        },
+        "vega-scenegraph": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-2.2.0.tgz",
+          "integrity": "sha512-XgMzZCH+5JrADjiWbt1++y7DtS4Sr6mqiOwlxpfJnGsm9bJDliIO9uMOxpSTnlTSKyac8AZjxSfKRKRRTk/qqQ==",
+          "requires": {
+            "d3-path": "1.0.5",
+            "d3-shape": "1.2.0",
+            "vega-canvas": "1.0.1",
+            "vega-loader": "2.0.2",
+            "vega-util": "1.6.0"
+          }
+        },
+        "vega-view": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-2.1.0.tgz",
+          "integrity": "sha512-tHDYZp+debCkG8Q7apCkxrm39oJNP53bS5WY526d0ZlwbOBp8TbiaD0zURSQYcseogZwH88jl4Avsz8rcZycrA==",
+          "requires": {
+            "d3-array": "1.2.0",
+            "vega-dataflow": "3.0.3",
+            "vega-parser": "2.4.0",
+            "vega-runtime": "2.0.0",
+            "vega-scenegraph": "2.2.0",
+            "vega-util": "1.6.0"
+          }
+        },
+        "vega-wordcloud": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-2.1.0.tgz",
+          "integrity": "sha512-5kKjcse73d72OM1rBqWcbOpWKQeZrk/oVOxAG7EkGyElWQ+vIHBwj5qE4XYa1oIhhez25X1PVqhbzGMj1ZuKoQ==",
+          "requires": {
+            "vega-canvas": "1.0.1",
+            "vega-dataflow": "3.0.3",
+            "vega-scale": "2.1.0",
+            "vega-statistics": "1.2.1",
+            "vega-util": "1.6.0"
+          }
         },
         "window-size": {
           "version": "0.2.0",
@@ -13088,6 +13141,11 @@
           }
         }
       }
+    },
+    "vega-canvas": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.0.1.tgz",
+      "integrity": "sha512-2ng3O+cOCRwDXqZ+kk1nkeBWCK7Z029dZUTj6wdl36VSEZbcnnsj7bVgwsxni/4k8EPSecIMUPSaCgCj7/llMQ=="
     },
     "vega-crossfilter": {
       "version": "2.0.0",
@@ -13361,24 +13419,6 @@
         }
       }
     },
-    "vega-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-2.2.0.tgz",
-      "integrity": "sha512-/CqlfFGk/I+QfWWO4QaCE9Mds6bvEh0Vrhp0r3Thgj2KMaK3uHEFM1kS5y/LgdDYuBuPnlXZZ7gmJC0Er0KZ2w==",
-      "requires": {
-        "d3-array": "1.2.0",
-        "d3-color": "1.0.3",
-        "d3-format": "1.2.0",
-        "d3-time-format": "2.0.5",
-        "vega-dataflow": "3.0.3",
-        "vega-event-selector": "2.0.0",
-        "vega-expression": "2.3.1",
-        "vega-scale": "2.1.0",
-        "vega-scenegraph": "2.0.3",
-        "vega-statistics": "1.2.1",
-        "vega-util": "1.6.0"
-      }
-    },
     "vega-projection": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.0.0.tgz",
@@ -13443,7 +13483,7 @@
         "d3-format": "1.2.0",
         "d3-selection": "1.1.0",
         "d3-time-format": "2.0.5",
-        "vega": "3.0.5",
+        "vega": "3.0.10",
         "vega-lite": "2.0.0-rc4"
       }
     },
@@ -13463,19 +13503,6 @@
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.6.0.tgz",
       "integrity": "sha512-MB6r7A9XkVA+RWZHcr+CR5++/tsnOtO85tHb7lG8ZgL8BZf6A4okfziy0uAOFTug53cDOGqVkA/B4CdTFpxPWg=="
     },
-    "vega-view": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-2.0.3.tgz",
-      "integrity": "sha512-at0OBJ3ow97DH3ytOwp/RwNe/pSgR0BynTiMca/VeZu240eRVSaCYi7DyzPoyVJcc653Iiff+JyblVbqRnLeiw==",
-      "requires": {
-        "d3-array": "1.2.0",
-        "vega-dataflow": "3.0.3",
-        "vega-parser": "2.2.0",
-        "vega-runtime": "2.0.0",
-        "vega-scenegraph": "2.0.3",
-        "vega-util": "1.6.0"
-      }
-    },
     "vega-view-transforms": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-1.1.0.tgz",
@@ -13493,19 +13520,6 @@
       "requires": {
         "d3-voronoi": "1.1.2",
         "vega-dataflow": "3.0.3",
-        "vega-util": "1.6.0"
-      }
-    },
-    "vega-wordcloud": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-2.0.2.tgz",
-      "integrity": "sha512-EIzCv61KwUqpsVd7T2qVXwszE5wBVKRGDQjDS5au3/QNvx9g/DKM1Y9Fi5aXY5I2JXt3Ax5KtQoMygxqjVHSXw==",
-      "requires": {
-        "canvas": "1.6.5",
-        "canvas-prebuilt": "1.6.0",
-        "vega-dataflow": "3.0.3",
-        "vega-scale": "2.1.0",
-        "vega-statistics": "1.2.1",
         "vega-util": "1.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -91,12 +91,10 @@
     "telegraph-events": "^1.0.3",
     "underscore": "^1.8.3",
     "url-loader": "^0.5.8",
-    "vega": ">=3.0.0-rc1 <=3.0.9",
+    "vega": "^3.0.0-rc1",
     "vega-lite": "^2.0.0-beta.8",
-    "vega-scenegraph": "<=2.1",
     "vega-schema-url-parser": "^1.0.0-beta.2",
     "vega-tooltip": "^0.4.2",
-    "vega-wordcloud": "<=2.0.2",
     "webcola": "^3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit 46a97fcd8a84b10fdb00c73e2f6194a5a4c1582b since https://github.com/vega/vega-canvas/issues/1 is resolved and a new `vega-canvas` was released.