### PR TITLE
Don't rely on image tests to pass

### DIFF
--- a/packages/examples/test/imageTest.js
+++ b/packages/examples/test/imageTest.js
@@ -101,7 +101,8 @@ export default function imageTest ({name, dir, extraBaselines = [], url, selecto
           fs.writeFileSync(path.join(dirname, `${filename}-diff.png`), rawData(analysis.getImageDataUrl()), 'base64');
         }
 
-        t.ok(passed, `${name} image matches to within ${threshold * 100}% (actual diff: ${analysis.misMatchPercentage}%, baseline: ${filename}.png)`);
+        // t.ok(passed, `${name} image matches to within ${threshold * 100}% (actual diff: ${analysis.misMatchPercentage}%, baseline: ${filename}.png)`);
+        t.pass(`${name} image differs from baseline ${filename}.png by ${analysis.misMatchPercentage}%`);
 
         t.end();
         return n.end().then();

--- a/packages/examples/test/index.js
+++ b/packages/examples/test/index.js
@@ -3,10 +3,6 @@ import imageTest from './imageTest';
 imageTest({
   name: 'barchart',
   dir: 'barchart',
-  extraBaselines: [
-    'barchart-circle',
-    'barchart-circle2'
-  ],
   url: 'http://localhost:28000/bar',
   selector: '#vis-element',
   delay: 1000,
@@ -16,7 +12,6 @@ imageTest({
 imageTest({
   name: 'boxplot',
   dir: 'boxplot',
-  extraBaselines: ['boxplot-circle'],
   url: 'http://localhost:28000/box',
   selector: '#vis-element',
   delay: 1000,
@@ -26,7 +21,6 @@ imageTest({
 imageTest({
   name: 'ganttchart',
   dir: 'ganttchart',
-  extraBaselines: ['ganttchart-circle'],
   url: 'http://localhost:28000/gantt',
   selector: '#vis-element',
   delay: 2000,
@@ -36,7 +30,6 @@ imageTest({
 imageTest({
   name: 'histogram',
   dir: 'histogram',
-  extraBaselines: ['histogram-circle'],
   url: 'http://localhost:28000/histogram',
   selector: '#vis-element',
   delay: 1000,
@@ -46,7 +39,6 @@ imageTest({
 imageTest({
   name: 'linechart',
   dir: 'linechart',
-  extraBaselines: ['linechart-circle'],
   url: 'http://localhost:28000/line',
   selector: '#vis-element',
   delay: 1000,
@@ -56,10 +48,6 @@ imageTest({
 imageTest({
   name: 'linechart-points',
   dir: 'linechart',
-  extraBaselines: [
-    'linechart-points-circle',
-    'linechart-points-circle2'
-  ],
   url: 'http://localhost:28000/line-points',
   selector: '#vis-element',
   delay: 1000,
@@ -69,10 +57,6 @@ imageTest({
 imageTest({
   name: 'scatterplot',
   dir: 'scatterplot',
-  extraBaselines: [
-    'scatterplot-circle',
-    'scatterplot-circle2'
-  ],
   url: 'http://localhost:28000/scatter',
   selector: '#vis-element',
   delay: 1000,
@@ -82,7 +66,6 @@ imageTest({
 imageTest({
   name: 'scatterplot-solid',
   dir: 'scatterplot',
-  extraBaselines: ['scatterplot-solid-circle'],
   url: 'http://localhost:28000/scatter-solid',
   selector: '#vis-element',
   delay: 1000,
@@ -92,10 +75,6 @@ imageTest({
 imageTest({
   name: 'scatterplotmatrix',
   dir: 'scatterplotmatrix',
-  extraBaselines: [
-    'scatterplotmatrix-circle',
-    'scatterplotmatrix-circle2'
-  ],
   url: 'http://localhost:28000/scattermatrix',
   selector: '#vis-element',
   delay: 4000,
@@ -122,7 +101,6 @@ imageTest({
 imageTest({
   name: 'lineup',
   dir: 'lineup',
-  extraBaselines: ['lineup-circle'],
   url: 'http://localhost:28000/lineup',
   selector: '#vis-element',
   delay: 2000,
@@ -132,7 +110,6 @@ imageTest({
 imageTest({
   name: 'distributionplot',
   dir: 'distributionplot',
-  extraBaselines: ['distributionplot-circle'],
   url: 'http://localhost:28000/distribution',
   selector: '#vis-element',
   delay: 1000,
@@ -142,7 +119,6 @@ imageTest({
 imageTest({
   name: 'distributionplot-bimodal',
   dir: 'distributionplot',
-  extraBaselines: ['distributionplot-bimodal-circle'],
   url: 'http://localhost:28000/distribution-bimodal',
   selector: '#vis-element',
   delay: 1000,
@@ -152,7 +128,6 @@ imageTest({
 imageTest({
   name: 'normalprobabilityplot',
   dir: 'normalprobabilityplot',
-  extraBaselines: ['normalprobabilityplot-circle'],
   url: 'http://localhost:28000/normalprobability',
   selector: '#vis-element',
   delay: 1000,
@@ -162,7 +137,6 @@ imageTest({
 imageTest({
   name: 'normalprobabilityplot-bimodal',
   dir: 'normalprobabilityplot',
-  extraBaselines: ['normalprobabilityplot-bimodal-circle'],
   url: 'http://localhost:28000/normalprobability-bimodal',
   selector: '#vis-element',
   delay: 1000,

--- a/packages/lineup/src/LineUp/test/lineup.spec.js
+++ b/packages/lineup/src/LineUp/test/lineup.spec.js
@@ -1,3 +1,4 @@
+import { select } from 'd3-selection';
 import test from 'tape-catch';
 
 // needed to handle Babel's conversion of for `(x of array)`
@@ -8,6 +9,7 @@ import LineUp from '..';
 test('LineUp component', t => {
   const div = document.createElement('div');
   div.setAttribute('style', 'width: 800px; height: 600px');
+  document.body.appendChild(div);
 
   t.ok(LineUp, 'LineUp exists');
   t.ok(LineUp.options, 'LineUp options exists');
@@ -18,9 +20,9 @@ test('LineUp component', t => {
       {a: -1, b: 0, c: 'c', d: false}
     ],
     fields: ['d', 'a', 'c'],
-    stacked: false,
+    stacked: true,
     histograms: true,
-    animation: true
+    animation: false
   });
   t.ok(lu.lineUpConfig, 'LineUp configured');
   t.equal(lu.lineUpConfig.renderingOptions.histograms, true, 'LineUp options set');
@@ -29,5 +31,12 @@ test('LineUp component', t => {
   // still need to add tests for dragging columns and recording their weights,
   // tooltip updates, select callback, and date-based columns
 
-  t.end();
+  window.setTimeout(() => {
+    const rows = select(lu.el)
+      .selectAll('g.row')
+      .nodes();
+    t.assert(rows.length > 0, 'Plot has rendered some data rows');
+
+    t.end();
+  }, 200);
 });

--- a/packages/stats/src/DistributionPlot/test/distributionplot.spec.js
+++ b/packages/stats/src/DistributionPlot/test/distributionplot.spec.js
@@ -1,0 +1,35 @@
+import { select } from 'd3-selection';
+import test from 'tape-catch';
+
+import DistributionPlot from '..';
+
+function getY (txt) {
+  return +txt.split(',')[1].slice(0, -1);
+}
+
+test('DistributionPlot component', t => {
+  const data = [...Array(100).keys()].map(i => i % 2 === 0 ? i / 2 : 100 - Math.floor(i / 2));
+  const width = 400;
+  const height = 400;
+
+  let el = document.createElement('div');
+  let vis = new DistributionPlot(el, {
+    data,
+    width,
+    height,
+    renderer: 'svg'
+  });
+  vis.render();
+
+  const dotY = select(vis.el)
+    .select('.mark-symbol.role-mark.marks')
+    .selectAll('path')
+    .nodes()
+    .map((el) => getY(el.getAttribute('transform')));
+
+  const sorted = [...dotY].sort((x, y) => y - x);
+
+  t.deepEqual(sorted, dotY, 'Points should be plotted in ascending-y order');
+
+  t.end();
+});

--- a/packages/stats/src/NormalProbabilityPlot/test/normalprobabilityplot.spec.js
+++ b/packages/stats/src/NormalProbabilityPlot/test/normalprobabilityplot.spec.js
@@ -1,0 +1,35 @@
+import { select } from 'd3-selection';
+import test from 'tape-catch';
+
+import NormalProbabilityPlot from '..';
+
+function getY (txt) {
+  return +txt.split(',')[1].slice(0, -1);
+}
+
+test('NormalProbabilityPlot component', t => {
+  const data = [...Array(100).keys()].map(i => i % 2 === 0 ? i / 2 : 100 - Math.floor(i / 2));
+  const width = 400;
+  const height = 400;
+
+  let el = document.createElement('div');
+  let vis = new NormalProbabilityPlot(el, {
+    data,
+    width,
+    height,
+    renderer: 'svg'
+  });
+  vis.render();
+
+  const dotY = select(vis.el)
+    .select('.mark-symbol.role-mark.marks')
+    .selectAll('path')
+    .nodes()
+    .map((el) => getY(el.getAttribute('transform')));
+
+  const sorted = [...dotY].sort((x, y) => y - x);
+
+  t.deepEqual(sorted, dotY, 'Points should be plotted in ascending-y order');
+
+  t.end();
+});

--- a/packages/stats/src/test/dummy.spec.js
+++ b/packages/stats/src/test/dummy.spec.js
@@ -1,7 +1,0 @@
-import test from 'tape-catch';
-
-test('Dummy test', t => {
-  t.skip('dummy assertion');
-
-  t.end();
-});

--- a/packages/vega/src/component/BoxPlot/test/boxplot.spec.js
+++ b/packages/vega/src/component/BoxPlot/test/boxplot.spec.js
@@ -1,0 +1,53 @@
+import { select } from 'd3-selection';
+import test from 'tape-catch';
+
+import BoxPlot from '..';
+
+test('BoxPlot component', t => {
+  const data = [...Array(20).keys()].map(i => ({
+    a: `Field ${i % 3}`,
+    b: i,
+    c: i * i
+  }));
+  const width = 400;
+  const height = 450;
+  const fields = ['b', 'c'];
+
+  let el = document.createElement('div');
+  let vis = new BoxPlot(el, {
+    data,
+    fields,
+    x: 'a',
+    width,
+    height,
+    renderer: 'svg'
+  });
+  vis.render();
+
+  const titles = select(vis.el)
+    .selectAll('.mark-text.role-title')
+    .selectAll('text')
+    .nodes()
+    .map((el) => el.textContent);
+
+  t.deepEqual(titles, fields, 'Section titles should match requested fields');
+
+  const labels = select(vis.el)
+    .select('.mark-group.role-column-footer.column_footer')
+    .select('.mark-text.role-axis-label')
+    .selectAll('text')
+    .nodes()
+    .map((el) => el.textContent);
+
+  t.deepEqual(labels, [0, 1, 2].map(i => `Field ${i}`), 'x-axis labels should match categorical field names');
+
+  const layers = [0, 1, 2, 3].map(i => select(vis.el)
+    .select(`.role-mark.child_layer_${i}_marks`)
+    .selectAll('*')
+    .nodes()
+    .length);
+
+  t.ok(layers.every(x => x === 3), 'Plot has correct number of boxplot marks');
+
+  t.end();
+});

--- a/packages/vega/src/component/GanttChart/test/ganttchart.spec.js
+++ b/packages/vega/src/component/GanttChart/test/ganttchart.spec.js
@@ -1,0 +1,58 @@
+import { select } from 'd3-selection';
+import test from 'tape-catch';
+
+import GanttChart from '..';
+
+test('GanttChart component', t => {
+  const data = [
+    {name: '1. Algorithms', level: 1, enter: 0, leave: 6},
+    {name: 'Algorithm Specification', level: 2, enter: 0, leave: 2},
+    {name: 'Algorithm Implementation', level: 2, enter: 1, leave: 6},
+    {name: '2. Software Prototype', level: 1, enter: 1, leave: 8},
+    {name: 'Support Data Formats', level: 2, enter: 1, leave: 3},
+    {name: 'Modular Analyses/Workflows', level: 2, enter: 3, leave: 5},
+    {name: 'Web Interface and Mockups', level: 2, enter: 5, leave: 8},
+    {name: '3. Evaluation and Team-Building', level: 1, enter: 0, leave: 9},
+    {name: 'Data Collection', level: 2, enter: 0, leave: 2},
+    {name: 'Algorithmic Evaluation', level: 2, enter: 6, leave: 8},
+    {name: 'Usability Evaluation', level: 2, enter: 7, leave: 9},
+    {name: 'Final Report', level: 2, enter: 8, leave: 9}
+  ];
+
+  let el = document.createElement('div');
+  let vis = new GanttChart(el, {
+    data,
+    start: 'enter',
+    end: 'leave',
+    label: 'name',
+    level: 'level',
+    tickCount: 10,
+    axisTitle: 'Month',
+    width: 500,
+    height: 300,
+    renderer: 'svg'
+  });
+  vis.render();
+
+  const bars = select(vis.el)
+    .select('.mark-rect.role-mark.marks')
+    .selectAll('path')
+    .nodes();
+  t.equal(bars.length, 12, 'Chart has correct number of bars');
+
+  const labelAxis = select(vis.el)
+    .selectAll('.mark-group.role-axis')
+    .nodes();
+
+  const labels = select(labelAxis[2])
+    .select('.mark-text.role-axis-label')
+    .selectAll('text')
+    .nodes()
+    .map((el) => el.textContent);
+
+  labels.forEach((label, i) => {
+    t.deepEqual(label, data[i].name, `Chart has correct label for item ${i}`);
+  });
+
+  t.end();
+});

--- a/packages/vega/src/component/Histogram/test/histogram.spec.js
+++ b/packages/vega/src/component/Histogram/test/histogram.spec.js
@@ -1,0 +1,32 @@
+import { select } from 'd3-selection';
+import test from 'tape-catch';
+
+import Histogram from '..';
+
+test('Histogram component', t => {
+  const data = [...Array(200).keys()].map(i => ({
+    a: Math.floor(i / 10)
+  }));
+  const width = 400;
+  const height = 400;
+  const maxBins = 10;
+
+  let el = document.createElement('div');
+  let vis = new Histogram(el, {
+    data,
+    x: 'a',
+    maxBins,
+    width,
+    height,
+    renderer: 'svg'
+  });
+  vis.render();
+
+  const bars = select(vis.el)
+    .select('.mark-rect.role-mark.marks')
+    .selectAll('path')
+    .nodes();
+  t.equal(bars.length, maxBins, 'Plot has correct number of bin marks');
+
+  t.end();
+});

--- a/packages/vega/src/component/LineChart/test/linechart.spec.js
+++ b/packages/vega/src/component/LineChart/test/linechart.spec.js
@@ -1,0 +1,31 @@
+import { select } from 'd3-selection';
+import test from 'tape-catch';
+
+import LineChart from '..';
+
+test('LineChart component', t => {
+  const data = [...Array(20).keys()].map(i => ({
+    a: i,
+    b: i * i
+  }));
+  const width = 400;
+  const height = 400;
+
+  let el = document.createElement('div');
+  let vis = new LineChart(el, {
+    data,
+    x: 'a',
+    y: 'b',
+    width,
+    height,
+    renderer: 'svg'
+  });
+  vis.render();
+
+  let lines = select(vis.el)
+    .select('.mark-line.role-mark')
+    .nodes();
+  t.equal(lines.length, 1, 'Plot should have one line element');
+
+  t.end();
+});

--- a/packages/vega/src/component/ScatterPlot/test/scatterplot.spec.js
+++ b/packages/vega/src/component/ScatterPlot/test/scatterplot.spec.js
@@ -1,0 +1,34 @@
+import { select } from 'd3-selection';
+import test from 'tape-catch';
+
+import ScatterPlot from '..';
+
+test('ScatterPlot component', t => {
+  const data = [...Array(20).keys()].map(i => ({
+    a: i / 2,
+    b: i * i,
+    c: i
+  }));
+  const width = 400;
+  const height = 400;
+
+  let el = document.createElement('div');
+  let vis = new ScatterPlot(el, {
+    data,
+    x: 'a',
+    y: 'b',
+    color: 'c',
+    width,
+    height,
+    renderer: 'svg'
+  });
+  vis.render();
+
+  const marks = select(vis.el)
+    .select('.mark-symbol.role-mark.marks')
+    .selectAll('path')
+    .nodes();
+  t.equal(marks.length, 20, 'Plot has the correct number of data marks');
+
+  t.end();
+});

--- a/packages/vega/src/component/ScatterPlotMatrix/test/scatterplotmatrix.spec.js
+++ b/packages/vega/src/component/ScatterPlotMatrix/test/scatterplotmatrix.spec.js
@@ -1,0 +1,40 @@
+import { select } from 'd3-selection';
+import test from 'tape-catch';
+
+import ScatterPlotMatrix from '..';
+
+test('ScatterPlot component', t => {
+  const data = [...Array(20).keys()].map(i => ({
+    a: i / 2,
+    b: i * i,
+    c: i,
+    d: -i * i * i
+  }));
+  const width = 400;
+  const height = 400;
+  const fields = ['a', 'b', 'c', 'd'];
+
+  let el = document.createElement('div');
+  let vis = new ScatterPlotMatrix(el, {
+    data,
+    fields,
+    color: 'c',
+    width,
+    height,
+    renderer: 'svg'
+  });
+  vis.render();
+
+  const plots = select(vis.el)
+    .selectAll('.mark-group.role-scope')
+    .nodes();
+  t.equal(plots.length, fields.length * fields.length, 'Plot contains correct number of subplots');
+
+  const points = select(vis.el)
+    .select('.mark-symbol.role-mark')
+    .selectAll('path')
+    .nodes();
+  t.equal(points.length, data.length, 'Subplot has the correct number of data marks');
+
+  t.end();
+});

--- a/packages/vega/src/test/dummy.spec.js
+++ b/packages/vega/src/test/dummy.spec.js
@@ -1,7 +1,0 @@
-import test from 'tape-catch';
-
-test('Dummy test', t => {
-  t.skip('dummy assertion');
-
-  t.end();
-});


### PR DESCRIPTION
This PR retains the image testing infrastructure, but just allows all image tests to pass. The test message has been updated to simply report how far the rendered image is from the baseline. These are being kept as a sanity checking mechanism.

To replace some thrust of the image testing functionality, the unit tests have been extended to render each vis that used to be image tested, and asssert some things about its HTML structure, etc.